### PR TITLE
Jan 735 cast limit and page to numbers

### DIFF
--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -169,7 +169,7 @@ describe('Api List Data', () => {
 			});
 		});
 
-		it('Should throw if headers are invalid strings', async () => {
+		it('Should throw if page header is invalid strings', async () => {
 
 			const getModelInstanceFake = sandbox.stub(ApiListData.prototype, '_getModelInstance');
 			getModelInstanceFake.returns({});
@@ -178,14 +178,32 @@ describe('Api List Data', () => {
 			apiListData.endpoint = '/some-entity';
 			apiListData.data = {};
 			apiListData.headers = {
-				'x-janis-page': '1page',
-				'x-janis-page-size': '60'
+				'x-janis-page': '1page'
 			};
 
 			await assert.rejects(() => apiListData.validate(), err => {
 				return err instanceof ApiListError
 					&& !!err.message.includes('x-janis-page')
 					&& !!err.message.includes('1page');
+			});
+		});
+
+		it('Should throw if page size header is invalid strings', async () => {
+
+			const getModelInstanceFake = sandbox.stub(ApiListData.prototype, '_getModelInstance');
+			getModelInstanceFake.returns({});
+
+			const apiListData = new ApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {};
+			apiListData.headers = {
+				'x-janis-page-size': '60pages'
+			};
+
+			await assert.rejects(() => apiListData.validate(), err => {
+				return err instanceof ApiListError
+					&& !!err.message.includes('x-janis-page-size')
+					&& !!err.message.includes('60pages');
 			});
 		});
 


### PR DESCRIPTION
LINK AL TICKET
https://fizzmod.atlassian.net/browse/JAN-735

DESCRIPCIÓN DEL REQUERIMIENTO
Es necesario castear los datos de page y limit que se envía al modelo mediante el api list, esto debido a que los headers llegan como strings, pero mongo no los admite.

DESCRIPCIÓN DE LA SOLUCIÓN
Se realizó la conversión de dichos datos a Number con lo cual se previene que lleguen como strings, adicional a esto se añadieron los tests para estos casos.