### PR TITLE
Jcn 351 multiple sort direction to api list package

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,52 @@ This fields **must** be defined in the model.
 ### get sortableFields()
 This is used to indicate which fields can be used to sort the list. Any other sort field will return a 400 status code.
 
+For example:
+```js
+'use strict';
+
+const {
+	ApiListData
+} = require('@janiscommerce/api-list');
+
+module.exports = class MyApiListData extends ApiListData {
+
+	get sortableFields() {
+		return ['foo', 'bar'];
+	}
+};
+```
+
+* `/api/entity?sortBy=foo` with a single value.
+
+Will sort the list by `foo` in direction `asc` that are the *default* 
+
+* `/api/entity?sortBy=foo&&sortDirection=desc` with a single value.
+
+Will sort the list by `foo` in direction `desc`
+
+💡 Also, we can pass **sortBy** as `array`
+
+* `/api/entity?sortBy[0]=foo&&sortBy[1]=bar` with a single value.
+
+Will sort the list by `foo` and `bar` in direction `asc` that are the *default* 
+
+* `/api/entity?sortBy[0]=foo&&sortBy[1]=bar&&sortDirection=desc` with a single value.
+
+Will sort the list by `foo` and `bar` in direction `desc`
+
+💡 We can pass an `array` to **sortDirection** indexing with **sortBy**
+
+* `/api/entity?sortBy[0]=foo&&sortBy[1]=bar&&sortDirection[0]=desc&&sortDirection[1]=asc` with a single value.
+
+Will sort the list by `foo` in direction `desc` and `bar` in direction `asc`
+
+❗ When not index a field, it will set with the *default value*
+
+* `/api/entity?sortBy[0]=foo&&sortBy[1]=bar&&sortDirection[1]=desc` with a single value.
+
+Will sort the list by `foo` in direction `asc` because is the *default value* and `bar` in direction `desc`
+
 ### get availableFilters()
 This is used to indicate which fields can be used to filter the list. Any other filter will return a 400 status code.
 Filters can be customized by passing an object with the following properties:

--- a/README.md
+++ b/README.md
@@ -91,9 +91,7 @@ For example:
 ```js
 'use strict';
 
-const {
-	ApiListData
-} = require('@janiscommerce/api-list');
+const { ApiListData } = require('@janiscommerce/api-list');
 
 module.exports = class MyApiListData extends ApiListData {
 
@@ -107,23 +105,23 @@ module.exports = class MyApiListData extends ApiListData {
 
 Will sort the list by `foo` in direction `asc` that are the *default* 
 
-* `/api/entity?sortBy=foo&&sortDirection=desc` with a single value.
+* `/api/entity?sortBy=foo&sortDirection=desc` with a single value.
 
 Will sort the list by `foo` in direction `desc`
 
-* `/api/entity?sortBy[0]=foo&&sortBy[1]=bar` with a single value.
+* `/api/entity?sortBy[0]=foo&sortBy[1]=bar` with a single value.
 
 Will sort the list by `foo` and `bar` in direction `asc` that are the *default* 
 
-* `/api/entity?sortBy[0]=foo&&sortBy[1]=bar&&sortDirection=desc` with a single value.
+* `/api/entity?sortBy[0]=foo&sortBy[1]=bar&sortDirection=desc` with a single value.
 
 Will sort the list by `foo` and `bar` in direction `desc`
 
-* `/api/entity?sortBy[0]=foo&&sortBy[1]=bar&&sortDirection[0]=desc&&sortDirection[1]=asc` with a single value.
+* `/api/entity?sortBy[0]=foo&sortBy[1]=bar&sortDirection[0]=desc&sortDirection[1]=asc` with a single value.
 
 Will sort the list by `foo` in direction `desc` and `bar` in direction `asc`. The **sortDirection** is indexed with **sortBy**
 
-* `/api/entity?sortBy[0]=foo&&sortBy[1]=bar&&sortDirection[1]=desc` with a single value.
+* `/api/entity?sortBy[0]=foo&sortBy[1]=bar&sortDirection[1]=desc` with a single value.
 
 Will sort the list by `foo` in direction `asc` because is the *default value* and `bar` in direction `desc`
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,6 @@ Will sort the list by `foo` in direction `asc` that are the *default*
 
 Will sort the list by `foo` in direction `desc`
 
-💡 Also, we can pass **sortBy** as `array`
-
 * `/api/entity?sortBy[0]=foo&&sortBy[1]=bar` with a single value.
 
 Will sort the list by `foo` and `bar` in direction `asc` that are the *default* 
@@ -121,13 +119,9 @@ Will sort the list by `foo` and `bar` in direction `asc` that are the *default*
 
 Will sort the list by `foo` and `bar` in direction `desc`
 
-💡 We can pass an `array` to **sortDirection** indexing with **sortBy**
-
 * `/api/entity?sortBy[0]=foo&&sortBy[1]=bar&&sortDirection[0]=desc&&sortDirection[1]=asc` with a single value.
 
-Will sort the list by `foo` in direction `desc` and `bar` in direction `asc`
-
-❗ When not index a field, it will set with the *default value*
+Will sort the list by `foo` in direction `desc` and `bar` in direction `asc`. The **sortDirection** is indexed with **sortBy**
 
 * `/api/entity?sortBy[0]=foo&&sortBy[1]=bar&&sortDirection[1]=desc` with a single value.
 

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -53,10 +53,14 @@ class ApiListData extends API {
 		});
 
 		try {
+
 			this.dataWithDefaults = listDataStruct({
 				...this.data,
 				...(Object.keys(requestFilters).length ? { filters: requestFilters } : {})
 			});
+
+			this.sort.validate();
+
 		} catch(e) {
 			throw new ApiListError(e, ApiListError.codes.INVALID_REQUEST_DATA);
 		}

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -44,8 +44,6 @@ class ApiListData extends API {
 		this.paging = new Paging(this.headers, (this.session && this.session.isService));
 		this.sort = new Sort(this.data, this.sortableFields);
 
-		console.log('this.data', this.data);
-
 		const listDataStruct = struct({
 			...this.filter.struct(),
 			...this.sort.struct()
@@ -59,8 +57,6 @@ class ApiListData extends API {
 				...this.data,
 				...(Object.keys(requestFilters).length ? { filters: requestFilters } : {})
 			});
-
-			console.log(this.dataWithDefaults);
 		} catch(e) {
 			throw new ApiListError(e, ApiListError.codes.INVALID_REQUEST_DATA);
 		}
@@ -89,8 +85,6 @@ class ApiListData extends API {
 				...this.sort.getParams(this.dataWithDefaults),
 				...this.paging.getParams(this.headersWithDefaults)
 			};
-
-			console.log('getParams:', getParams);
 
 			if(this.fieldsToSelect)
 				getParams.fields = this.fieldsToSelect;

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -44,6 +44,8 @@ class ApiListData extends API {
 		this.paging = new Paging(this.headers, (this.session && this.session.isService));
 		this.sort = new Sort(this.data, this.sortableFields);
 
+		console.log('this.data', this.data);
+
 		const listDataStruct = struct({
 			...this.filter.struct(),
 			...this.sort.struct()
@@ -57,6 +59,8 @@ class ApiListData extends API {
 				...this.data,
 				...(Object.keys(requestFilters).length ? { filters: requestFilters } : {})
 			});
+
+			console.log(this.dataWithDefaults);
 		} catch(e) {
 			throw new ApiListError(e, ApiListError.codes.INVALID_REQUEST_DATA);
 		}
@@ -85,6 +89,8 @@ class ApiListData extends API {
 				...this.sort.getParams(this.dataWithDefaults),
 				...this.paging.getParams(this.headersWithDefaults)
 			};
+
+			console.log('getParams:', getParams);
 
 			if(this.fieldsToSelect)
 				getParams.fields = this.fieldsToSelect;

--- a/lib/data-helpers/sort.js
+++ b/lib/data-helpers/sort.js
@@ -7,7 +7,7 @@ const SORT_DIRECTION_PARAMETER = 'sortDirection';
 
 const DEFAULT_SORT_DIRECTION = 'asc';
 
-const sortDirections = ['asc', 'desc', 'ASC', 'DESC'];
+const sortDirections = ['asc', 'desc', 'ASC', 'DESC', undefined];
 
 class ListSort {
 
@@ -22,8 +22,12 @@ class ListSort {
 			return {};
 
 		return {
-			[SORT_PARAMETER]: struct.optional(struct.enum(this.sortableFields)),
-			[SORT_DIRECTION_PARAMETER]: struct.optional(struct.enum(sortDirections))
+			[SORT_PARAMETER]: struct.optional(struct.dynamic(value => struct(value instanceof Array ?
+				[struct.enum(this.sortableFields)] :
+				struct.enum(this.sortableFields)))),
+			[SORT_DIRECTION_PARAMETER]: struct.optional(struct.dynamic(value => struct(value instanceof Array ?
+				[struct.enum(sortDirections)] :
+				struct.enum(sortDirections))))
 		};
 	}
 
@@ -35,14 +39,28 @@ class ListSort {
 
 	getParams(clientParamsWithDefaults) {
 
-		if(!clientParamsWithDefaults[SORT_PARAMETER])
+		const sortParameters = clientParamsWithDefaults[SORT_PARAMETER];
+
+		if(!sortParameters)
 			return {};
 
-		return {
-			order: {
-				[clientParamsWithDefaults[SORT_PARAMETER]]: clientParamsWithDefaults[SORT_DIRECTION_PARAMETER].toLowerCase()
-			}
+		const response = {
+			order: {}
 		};
+
+		if(typeof sortParameters === 'string') {
+			response.order[clientParamsWithDefaults[SORT_PARAMETER]] = clientParamsWithDefaults[SORT_DIRECTION_PARAMETER].toLowerCase();
+			return response;
+		}
+
+		return sortParameters.reduce((accumOfParam, param, index) => {
+
+			const sortDirection = clientParamsWithDefaults[SORT_DIRECTION_PARAMETER];
+
+			accumOfParam.order[param] = sortDirection instanceof Array && sortDirection[index] ? sortDirection[index].toLowerCase() : DEFAULT_SORT_DIRECTION;
+
+			return accumOfParam;
+		}, response);
 	}
 
 }

--- a/lib/data-helpers/sort.js
+++ b/lib/data-helpers/sort.js
@@ -7,7 +7,7 @@ const SORT_DIRECTION_PARAMETER = 'sortDirection';
 
 const DEFAULT_SORT_DIRECTION = 'asc';
 
-const sortDirections = ['asc', 'desc', 'ASC', 'DESC', undefined];
+const sortDirections = ['asc', 'desc', 'ASC', 'DESC'];
 
 class ListSort {
 
@@ -22,12 +22,30 @@ class ListSort {
 			return {};
 
 		return {
-			[SORT_PARAMETER]: struct.optional(struct.dynamic(value => struct(value instanceof Array ?
-				[struct.enum(this.sortableFields)] :
-				struct.enum(this.sortableFields)))),
-			[SORT_DIRECTION_PARAMETER]: struct.optional(struct.dynamic(value => struct(value instanceof Array ?
-				[struct.enum(sortDirections)] :
-				struct.enum(sortDirections))))
+			[SORT_PARAMETER]: struct.optional(struct.dynamic(value => {
+
+				if(value instanceof Array) {
+
+					if(value.length > 3)
+						throw new Error('Maximum amount of field to sort is 3');
+
+					return struct([struct.enum(this.sortableFields)]);
+				}
+
+				return struct(struct.enum(this.sortableFields));
+			})),
+			[SORT_DIRECTION_PARAMETER]: struct.optional(struct.dynamic(value => {
+
+				if(value instanceof Array) {
+
+					if(this.isString(this.requestParameters[SORT_PARAMETER]))
+						throw new Error('The field sortDirection must be string when sortBy is string');
+
+					return struct([struct.enum([...sortDirections, undefined])]);
+				}
+
+				return struct(struct.enum(sortDirections));
+			}))
 		};
 	}
 
@@ -40,27 +58,41 @@ class ListSort {
 	getParams(clientParamsWithDefaults) {
 
 		const sortParameters = clientParamsWithDefaults[SORT_PARAMETER];
+		const sortDirection = clientParamsWithDefaults[SORT_DIRECTION_PARAMETER];
 
-		if(!sortParameters)
+		if(!sortParameters || !sortParameters.length)
 			return {};
 
-		const response = {
-			order: {}
-		};
+		const sanitizedSortDirection = this.sanitizeSortDirection(sortDirection);
 
-		if(typeof sortParameters === 'string') {
-			response.order[clientParamsWithDefaults[SORT_PARAMETER]] = clientParamsWithDefaults[SORT_DIRECTION_PARAMETER].toLowerCase();
-			return response;
+		if(this.isString(sortParameters)) {
+			return {
+				order: {
+					[sortParameters]: sanitizedSortDirection
+				}
+			};
 		}
 
 		return sortParameters.reduce((accumOfParam, param, index) => {
 
-			const sortDirection = clientParamsWithDefaults[SORT_DIRECTION_PARAMETER];
-
-			accumOfParam.order[param] = sortDirection instanceof Array && sortDirection[index] ? sortDirection[index].toLowerCase() : DEFAULT_SORT_DIRECTION;
+			accumOfParam.order[param] = sortDirection instanceof Array && sortDirection[index] ? sanitizedSortDirection[index] : DEFAULT_SORT_DIRECTION;
 
 			return accumOfParam;
-		}, response);
+		}, {
+			order: {}
+		});
+	}
+
+	sanitizeSortDirection(sortDirection) {
+
+		if(this.isString(sortDirection))
+			return sortDirection.toLowerCase();
+
+		return sortDirection.map(direction => direction && direction.toLowerCase());
+	}
+
+	isString(value) {
+		return typeof value === 'string';
 	}
 
 }

--- a/lib/data-helpers/sort.js
+++ b/lib/data-helpers/sort.js
@@ -22,31 +22,21 @@ class ListSort {
 			return {};
 
 		return {
-			[SORT_PARAMETER]: struct.optional(struct.dynamic(value => {
-
-				if(value instanceof Array) {
-
-					if(value.length > 3)
-						throw new Error('Maximum amount of field to sort is 3');
-
-					return struct([struct.enum(this.sortableFields)]);
-				}
-
-				return struct(struct.enum(this.sortableFields));
-			})),
-			[SORT_DIRECTION_PARAMETER]: struct.optional(struct.dynamic(value => {
-
-				if(value instanceof Array) {
-
-					if(this.isString(this.requestParameters[SORT_PARAMETER]))
-						throw new Error('The field sortDirection must be string when sortBy is string');
-
-					return struct([struct.enum([...sortDirections, undefined])]);
-				}
-
-				return struct(struct.enum(sortDirections));
-			}))
+			[SORT_PARAMETER]: struct.optional(struct.union([[struct.enum(this.sortableFields)], struct.enum(this.sortableFields)])),
+			[SORT_DIRECTION_PARAMETER]: struct.optional(struct.union([[struct.enum([...sortDirections, undefined])], struct.enum(sortDirections)]))
 		};
+	}
+
+	validate() {
+
+		const requestedSortParameters = this.requestParameters[SORT_PARAMETER];
+		const requestedSortDirections = this.requestParameters[SORT_DIRECTION_PARAMETER];
+
+		if(requestedSortParameters instanceof Array && requestedSortParameters.length > 3)
+			throw new Error('Maximum amount of field to sort is 3');
+
+		if(this.isString(requestedSortParameters) && requestedSortDirections instanceof Array)
+			throw new Error('The field sortDirection must be string when sortBy is string');
 	}
 
 	defaults() {
@@ -73,11 +63,16 @@ class ListSort {
 			};
 		}
 
-		return sortParameters.reduce((accumOfParam, param, index) => {
+		return sortParameters.reduce((accumOfFields, param, index) => {
 
-			accumOfParam.order[param] = sortDirection instanceof Array && sortDirection[index] ? sanitizedSortDirection[index] : DEFAULT_SORT_DIRECTION;
+			if(this.isString(sortDirection)) {
+				accumOfFields.order[param] = sortDirection;
+				return accumOfFields;
+			}
 
-			return accumOfParam;
+			accumOfFields.order[param] = sortDirection instanceof Array && sortDirection[index] ? sanitizedSortDirection[index] : DEFAULT_SORT_DIRECTION;
+
+			return accumOfFields;
 		}, {
 			order: {}
 		});
@@ -94,7 +89,6 @@ class ListSort {
 	isString(value) {
 		return typeof value === 'string';
 	}
-
 }
 
 module.exports = ListSort;

--- a/lib/data-helpers/sort.js
+++ b/lib/data-helpers/sort.js
@@ -30,13 +30,9 @@ class ListSort {
 	validate() {
 
 		const requestedSortParameters = this.requestParameters[SORT_PARAMETER];
-		const requestedSortDirections = this.requestParameters[SORT_DIRECTION_PARAMETER];
 
 		if(requestedSortParameters instanceof Array && requestedSortParameters.length > 3)
 			throw new Error('Maximum amount of field to sort is 3');
-
-		if(this.isString(requestedSortParameters) && requestedSortDirections instanceof Array)
-			throw new Error('The field sortDirection must be string when sortBy is string');
 	}
 
 	defaults() {
@@ -56,9 +52,18 @@ class ListSort {
 		const sanitizedSortDirection = this.sanitizeSortDirection(sortDirection);
 
 		if(this.isString(sortParameters)) {
+
+			if(sanitizedSortDirection instanceof Array && sanitizedSortDirection[0]) {
+				return {
+					order: {
+						[sortParameters]: sanitizedSortDirection[0]
+					}
+				};
+			}
+
 			return {
 				order: {
-					[sortParameters]: sanitizedSortDirection
+					[sortParameters]: this.isString(sanitizedSortDirection) ? sanitizedSortDirection : DEFAULT_SORT_DIRECTION
 				}
 			};
 		}

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -993,6 +993,51 @@ describe('Api List Data', () => {
 				mockRequire.stop(modelPath);
 			});
 
+			it('Should pass client defined parameters to the model get and set sort direction if pass a string', async () => {
+
+				class MyModel {
+					async get() {
+						return [];
+					}
+				}
+
+				mockRequire(modelPath, MyModel);
+
+				sinon.spy(MyModel.prototype, 'get');
+
+				class MyApiListData extends ApiListData {
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
+				}
+
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: ['foo', 'bar'],
+					sortDirection: 'desc'
+				};
+				apiListData.headers = {
+					'x-janis-page': 2,
+					'x-janis-page-size': 20
+				};
+
+				await apiListData.validate();
+
+				await apiListData.process();
+
+				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
+					page: 2,
+					limit: 20,
+					order: {
+						foo: 'desc',
+						bar: 'desc'
+					}
+				});
+
+				mockRequire.stop(modelPath);
+			});
+
 			it('Should pass client defined parameters to the model get if pass sort field as empty array', async () => {
 
 				class MyModel {

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -238,32 +238,6 @@ describe('Api List Data', () => {
 			});
 		});
 
-		it('Should throw if invalid sort field is passed as array', async () => {
-
-			class MyApiListData extends ApiListData {
-
-				get sortableFields() {
-					return ['foo', 'bar'];
-				}
-			}
-
-			const apiListData = new MyApiListData();
-			apiListData.endpoint = '/some-entity';
-			apiListData.data = {
-				sortBy: ['foo', 'invalidField']
-			};
-			apiListData.headers = {
-				'x-janis-page': '3',
-				'x-janis-page-size': '20'
-			};
-
-			await assert.rejects(() => apiListData.validate(), err => {
-				return err instanceof ApiListError
-					&& !!err.message.includes('sortBy')
-					&& !!err.message.includes('invalidField');
-			});
-		});
-
 		it('Should throw if invalid sort direction is passed', async () => {
 
 			class MyApiListData extends ApiListData {
@@ -519,103 +493,187 @@ describe('Api List Data', () => {
 			assert.strictEqual(validation, undefined);
 		});
 
-		it('Should validate if sortBy property is passed as array', async () => {
+		context('When pass sortBy as array', () => {
 
-			class MyApiListData extends ApiListData {
+			it('Should validate if sortBy property is passed', async () => {
 
-				get sortableFields() {
-					return ['foo', 'bar'];
+				class MyApiListData extends ApiListData {
+
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
 				}
-			}
 
-			const apiListData = new MyApiListData();
-			apiListData.endpoint = '/some-entity';
-			apiListData.data = {
-				sortBy: ['foo', 'bar']
-			};
-			apiListData.headers = {
-				'x-janis-page': '3',
-				'x-janis-page-size': '20'
-			};
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: ['foo', 'bar']
+				};
+				apiListData.headers = {
+					'x-janis-page': '3',
+					'x-janis-page-size': '20'
+				};
 
-			const validation = await apiListData.validate();
+				const validation = await apiListData.validate();
 
-			assert.strictEqual(validation, undefined);
+				assert.strictEqual(validation, undefined);
+			});
+
+			it('Should throw if invalid sort field is passed', async () => {
+
+				class MyApiListData extends ApiListData {
+
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
+				}
+
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: ['foo', 'invalidField']
+				};
+				apiListData.headers = {
+					'x-janis-page': '3',
+					'x-janis-page-size': '20'
+				};
+
+				await assert.rejects(() => apiListData.validate(), err => {
+					return err instanceof ApiListError
+						&& !!err.message.includes('sortBy')
+						&& !!err.message.includes('invalidField');
+				});
+			});
+
+			it('Should throw if the length of the sort field is greater than the maximum allowed', async () => {
+
+				class MyApiListData extends ApiListData {
+
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
+				}
+
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: ['foo', 'bar', 'bar', 'foo']
+				};
+				apiListData.headers = {
+					'x-janis-page': '3',
+					'x-janis-page-size': '20'
+				};
+
+				await assert.rejects(() => apiListData.validate(), err => {
+					return err instanceof ApiListError
+						&& !!err.message.includes('Maximum amount of field to sort is');
+				});
+			});
 		});
 
-		it('Should validate if sortDirection is passed as array', async () => {
+		context('When sortDirection is passed as array', () => {
 
-			class MyApiListData extends ApiListData {
+			it('Should validate if sortDirection is passed', async () => {
 
-				get sortableFields() {
-					return ['foo', 'bar'];
+				class MyApiListData extends ApiListData {
+
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
 				}
-			}
 
-			const apiListData = new MyApiListData();
-			apiListData.endpoint = '/some-entity';
-			apiListData.data = {
-				sortBy: ['foo', 'bar'],
-				sortDirection: ['asc', 'desc']
-			};
-			apiListData.headers = {
-				'x-janis-page': '3',
-				'x-janis-page-size': '20'
-			};
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: ['foo', 'bar'],
+					sortDirection: ['asc', 'desc']
+				};
+				apiListData.headers = {
+					'x-janis-page': '3',
+					'x-janis-page-size': '20'
+				};
 
-			const validation = await apiListData.validate();
+				const validation = await apiListData.validate();
 
-			assert.strictEqual(validation, undefined);
-		});
+				assert.strictEqual(validation, undefined);
+			});
 
-		it('Should validate if sortDirection is passed as array', async () => {
+			it('Should validate if sortDirection is passed that contains undefined', async () => {
 
-			class MyApiListData extends ApiListData {
+				class MyApiListData extends ApiListData {
 
-				get sortableFields() {
-					return ['foo', 'bar'];
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
 				}
-			}
 
-			const apiListData = new MyApiListData();
-			apiListData.endpoint = '/some-entity';
-			apiListData.data = {
-				sortBy: ['foo', 'bar'],
-				sortDirection: ['asc', 'desc']
-			};
-			apiListData.headers = {
-				'x-janis-page': '3',
-				'x-janis-page-size': '20'
-			};
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: ['foo', 'bar'],
+					sortDirection: [undefined, 'desc']
+				};
+				apiListData.headers = {
+					'x-janis-page': '3',
+					'x-janis-page-size': '20'
+				};
 
-			const validation = await apiListData.validate();
+				const validation = await apiListData.validate();
 
-			assert.strictEqual(validation, undefined);
-		});
+				assert.strictEqual(validation, undefined);
+			});
 
-		it('Should validate if sortDirection is passed as array that contains undefined', async () => {
+			it('Should throw if invalid sort field is passed', async () => {
 
-			class MyApiListData extends ApiListData {
+				class MyApiListData extends ApiListData {
 
-				get sortableFields() {
-					return ['foo', 'bar'];
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
 				}
-			}
 
-			const apiListData = new MyApiListData();
-			apiListData.endpoint = '/some-entity';
-			apiListData.data = {
-				sortBy: ['foo', 'bar'],
-				sortDirection: [undefined, 'desc']
-			};
-			apiListData.headers = {
-				'x-janis-page': '3',
-				'x-janis-page-size': '20'
-			};
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortDirection: ['invalidDirection']
+				};
+				apiListData.headers = {
+					'x-janis-page': '3',
+					'x-janis-page-size': '20'
+				};
 
-			const validation = await apiListData.validate();
+				await assert.rejects(() => apiListData.validate(), err => {
+					return err instanceof ApiListError
+						&& !!err.message.includes('sortDirection')
+						&& !!err.message.includes('invalidDirection');
+				});
+			});
 
-			assert.strictEqual(validation, undefined);
+			it('Should throw if the sort field is string', async () => {
+
+				class MyApiListData extends ApiListData {
+
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
+				}
+
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: 'foo',
+					sortDirection: ['desc']
+				};
+				apiListData.headers = {
+					'x-janis-page': '3',
+					'x-janis-page-size': '20'
+				};
+
+				await assert.rejects(() => apiListData.validate(), err => {
+					return err instanceof ApiListError
+						&& !!err.message.includes('The field sortDirection must be string when sortBy is string');
+				});
+			});
 		});
 	});
 
@@ -799,141 +857,181 @@ describe('Api List Data', () => {
 			mockRequire.stop(modelPath);
 		});
 
-		/* eslint-disable-next-line max-len */
-		it('Should pass client defined parameters to the model get when it receives an array to sorted with and set default sort direction', async () => {
+		context('When pass sort field as array', () => {
 
-			class MyModel {
-				async get() {
-					return [];
+			it('Should pass client defined parameters to the model get and set default sort direction', async () => {
+
+				class MyModel {
+					async get() {
+						return [];
+					}
 				}
-			}
 
-			mockRequire(modelPath, MyModel);
+				mockRequire(modelPath, MyModel);
 
-			sinon.spy(MyModel.prototype, 'get');
+				sinon.spy(MyModel.prototype, 'get');
 
-			class MyApiListData extends ApiListData {
-				get sortableFields() {
-					return ['foo', 'bar'];
+				class MyApiListData extends ApiListData {
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
 				}
-			}
 
-			const apiListData = new MyApiListData();
-			apiListData.endpoint = '/some-entity';
-			apiListData.data = {
-				sortBy: ['foo', 'bar']
-			};
-			apiListData.headers = {
-				'x-janis-page': 2,
-				'x-janis-page-size': 20
-			};
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: ['foo', 'bar']
+				};
+				apiListData.headers = {
+					'x-janis-page': 2,
+					'x-janis-page-size': 20
+				};
 
-			await apiListData.validate();
+				await apiListData.validate();
 
-			await apiListData.process();
+				await apiListData.process();
 
-			sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
-				page: 2,
-				limit: 20,
-				order: {
-					foo: 'asc',
-					bar: 'asc'
-				}
+				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
+					page: 2,
+					limit: 20,
+					order: {
+						foo: 'asc',
+						bar: 'asc'
+					}
+				});
+
+				mockRequire.stop(modelPath);
 			});
 
-			mockRequire.stop(modelPath);
-		});
+			it('Should pass client defined parameters to the model get and set different sort direction to each one', async () => {
 
-		/* eslint-disable-next-line max-len */
-		it('Should pass client defined parameters to the model get when it receives an array to sorted with and set different sort direction to each one', async () => {
-
-			class MyModel {
-				async get() {
-					return [];
+				class MyModel {
+					async get() {
+						return [];
+					}
 				}
-			}
 
-			mockRequire(modelPath, MyModel);
+				mockRequire(modelPath, MyModel);
 
-			sinon.spy(MyModel.prototype, 'get');
+				sinon.spy(MyModel.prototype, 'get');
 
-			class MyApiListData extends ApiListData {
-				get sortableFields() {
-					return ['foo', 'bar'];
+				class MyApiListData extends ApiListData {
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
 				}
-			}
 
-			const apiListData = new MyApiListData();
-			apiListData.endpoint = '/some-entity';
-			apiListData.data = {
-				sortBy: ['foo', 'bar'],
-				sortDirection: ['asc', 'DESC']
-			};
-			apiListData.headers = {
-				'x-janis-page': 2,
-				'x-janis-page-size': 20
-			};
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: ['foo', 'bar'],
+					sortDirection: ['asc', 'DESC']
+				};
+				apiListData.headers = {
+					'x-janis-page': 2,
+					'x-janis-page-size': 20
+				};
 
-			await apiListData.validate();
+				await apiListData.validate();
 
-			await apiListData.process();
+				await apiListData.process();
 
-			sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
-				page: 2,
-				limit: 20,
-				order: {
-					foo: 'asc',
-					bar: 'desc'
-				}
+				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
+					page: 2,
+					limit: 20,
+					order: {
+						foo: 'asc',
+						bar: 'desc'
+					}
+				});
+
+				mockRequire.stop(modelPath);
 			});
 
-			mockRequire.stop(modelPath);
-		});
+			it('Should pass client defined parameters to the model get and set default sort direction if pass undefined', async () => {
 
-		/* eslint-disable-next-line max-len */
-		it('Should pass client defined parameters to the model get when it receives an array to sorted with and set default sort direction if pass undefined', async () => {
-
-			class MyModel {
-				async get() {
-					return [];
+				class MyModel {
+					async get() {
+						return [];
+					}
 				}
-			}
 
-			mockRequire(modelPath, MyModel);
+				mockRequire(modelPath, MyModel);
 
-			sinon.spy(MyModel.prototype, 'get');
+				sinon.spy(MyModel.prototype, 'get');
 
-			class MyApiListData extends ApiListData {
-				get sortableFields() {
-					return ['foo', 'bar'];
+				class MyApiListData extends ApiListData {
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
 				}
-			}
 
-			const apiListData = new MyApiListData();
-			apiListData.endpoint = '/some-entity';
-			apiListData.data = {
-				sortBy: ['foo', 'bar'],
-				sortDirection: [undefined, 'DESC']
-			};
-			apiListData.headers = {
-				'x-janis-page': 2,
-				'x-janis-page-size': 20
-			};
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: ['foo', 'bar'],
+					sortDirection: [undefined, 'DESC']
+				};
+				apiListData.headers = {
+					'x-janis-page': 2,
+					'x-janis-page-size': 20
+				};
 
-			await apiListData.validate();
+				await apiListData.validate();
 
-			await apiListData.process();
+				await apiListData.process();
 
-			sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
-				page: 2,
-				limit: 20,
-				order: {
-					foo: 'asc',
-					bar: 'desc'
-				}
+				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
+					page: 2,
+					limit: 20,
+					order: {
+						foo: 'asc',
+						bar: 'desc'
+					}
+				});
+
+				mockRequire.stop(modelPath);
 			});
 
-			mockRequire.stop(modelPath);
+			it('Should pass client defined parameters to the model get if pass sort field as empty array', async () => {
+
+				class MyModel {
+					async get() {
+						return [];
+					}
+				}
+
+				mockRequire(modelPath, MyModel);
+
+				sinon.spy(MyModel.prototype, 'get');
+
+				class MyApiListData extends ApiListData {
+					get sortableFields() {
+						return ['foo', 'bar'];
+					}
+				}
+
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					sortBy: []
+				};
+				apiListData.headers = {
+					'x-janis-page': 2,
+					'x-janis-page-size': 20
+				};
+
+				await apiListData.validate();
+
+				await apiListData.process();
+
+				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
+					page: 2,
+					limit: 20
+				});
+
+				mockRequire.stop(modelPath);
+			});
 		});
 
 		it('Should pass client defined parameters to the model get when it receives an array to filter with ', async () => {

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -238,7 +238,7 @@ describe('Api List Data', () => {
 			});
 		});
 
-		it('Should throw if invalid sort field is passed in array', async () => {
+		it('Should throw if invalid sort field is passed as array', async () => {
 
 			class MyApiListData extends ApiListData {
 

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -858,7 +858,7 @@ describe('Api List Data', () => {
 
 		context('When pass sortDirection as array', () => {
 
-			it('Should pass client defined parameters to the model get and set the first index to sortBy', async () => {
+			it('Should pass client defined parameters to the model get and set the first index to field', async () => {
 
 				class MyModel {
 					async get() {
@@ -902,7 +902,7 @@ describe('Api List Data', () => {
 				mockRequire.stop(modelPath);
 			});
 
-			it('Should pass client defined parameters to the model get and set the default value to sortBy if the first index is undefined', async () => {
+			it('Should pass client defined parameters to the model get and set the default value to field if the first index is undefined', async () => {
 
 				class MyModel {
 					async get() {

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -238,6 +238,32 @@ describe('Api List Data', () => {
 			});
 		});
 
+		it('Should throw if invalid sort field is passed in array', async () => {
+
+			class MyApiListData extends ApiListData {
+
+				get sortableFields() {
+					return ['foo', 'bar'];
+				}
+			}
+
+			const apiListData = new MyApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {
+				sortBy: ['foo', 'invalidField']
+			};
+			apiListData.headers = {
+				'x-janis-page': '3',
+				'x-janis-page-size': '20'
+			};
+
+			await assert.rejects(() => apiListData.validate(), err => {
+				return err instanceof ApiListError
+					&& !!err.message.includes('sortBy')
+					&& !!err.message.includes('invalidField');
+			});
+		});
+
 		it('Should throw if invalid sort direction is passed', async () => {
 
 			class MyApiListData extends ApiListData {
@@ -492,6 +518,105 @@ describe('Api List Data', () => {
 
 			assert.strictEqual(validation, undefined);
 		});
+
+		it('Should validate if sortBy property is passed as array', async () => {
+
+			class MyApiListData extends ApiListData {
+
+				get sortableFields() {
+					return ['foo', 'bar'];
+				}
+			}
+
+			const apiListData = new MyApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {
+				sortBy: ['foo', 'bar']
+			};
+			apiListData.headers = {
+				'x-janis-page': '3',
+				'x-janis-page-size': '20'
+			};
+
+			const validation = await apiListData.validate();
+
+			assert.strictEqual(validation, undefined);
+		});
+
+		it('Should validate if sortDirection is passed as array', async () => {
+
+			class MyApiListData extends ApiListData {
+
+				get sortableFields() {
+					return ['foo', 'bar'];
+				}
+			}
+
+			const apiListData = new MyApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {
+				sortBy: ['foo', 'bar'],
+				sortDirection: ['asc', 'desc']
+			};
+			apiListData.headers = {
+				'x-janis-page': '3',
+				'x-janis-page-size': '20'
+			};
+
+			const validation = await apiListData.validate();
+
+			assert.strictEqual(validation, undefined);
+		});
+
+		it('Should validate if sortDirection is passed as array', async () => {
+
+			class MyApiListData extends ApiListData {
+
+				get sortableFields() {
+					return ['foo', 'bar'];
+				}
+			}
+
+			const apiListData = new MyApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {
+				sortBy: ['foo', 'bar'],
+				sortDirection: ['asc', 'desc']
+			};
+			apiListData.headers = {
+				'x-janis-page': '3',
+				'x-janis-page-size': '20'
+			};
+
+			const validation = await apiListData.validate();
+
+			assert.strictEqual(validation, undefined);
+		});
+
+		it('Should validate if sortDirection is passed as array that contains undefined', async () => {
+
+			class MyApiListData extends ApiListData {
+
+				get sortableFields() {
+					return ['foo', 'bar'];
+				}
+			}
+
+			const apiListData = new MyApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {
+				sortBy: ['foo', 'bar'],
+				sortDirection: [undefined, 'desc']
+			};
+			apiListData.headers = {
+				'x-janis-page': '3',
+				'x-janis-page-size': '20'
+			};
+
+			const validation = await apiListData.validate();
+
+			assert.strictEqual(validation, undefined);
+		});
 	});
 
 	describe('Validation with MS_PATH', () => {
@@ -668,6 +793,143 @@ describe('Api List Data', () => {
 				filters: {
 					id: '10',
 					id2: 100
+				}
+			});
+
+			mockRequire.stop(modelPath);
+		});
+
+		/* eslint-disable-next-line max-len */
+		it('Should pass client defined parameters to the model get when it receives an array to sorted with and set default sort direction', async () => {
+
+			class MyModel {
+				async get() {
+					return [];
+				}
+			}
+
+			mockRequire(modelPath, MyModel);
+
+			sinon.spy(MyModel.prototype, 'get');
+
+			class MyApiListData extends ApiListData {
+				get sortableFields() {
+					return ['foo', 'bar'];
+				}
+			}
+
+			const apiListData = new MyApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {
+				sortBy: ['foo', 'bar']
+			};
+			apiListData.headers = {
+				'x-janis-page': 2,
+				'x-janis-page-size': 20
+			};
+
+			await apiListData.validate();
+
+			await apiListData.process();
+
+			sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
+				page: 2,
+				limit: 20,
+				order: {
+					foo: 'asc',
+					bar: 'asc'
+				}
+			});
+
+			mockRequire.stop(modelPath);
+		});
+
+		/* eslint-disable-next-line max-len */
+		it('Should pass client defined parameters to the model get when it receives an array to sorted with and set different sort direction to each one', async () => {
+
+			class MyModel {
+				async get() {
+					return [];
+				}
+			}
+
+			mockRequire(modelPath, MyModel);
+
+			sinon.spy(MyModel.prototype, 'get');
+
+			class MyApiListData extends ApiListData {
+				get sortableFields() {
+					return ['foo', 'bar'];
+				}
+			}
+
+			const apiListData = new MyApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {
+				sortBy: ['foo', 'bar'],
+				sortDirection: ['asc', 'DESC']
+			};
+			apiListData.headers = {
+				'x-janis-page': 2,
+				'x-janis-page-size': 20
+			};
+
+			await apiListData.validate();
+
+			await apiListData.process();
+
+			sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
+				page: 2,
+				limit: 20,
+				order: {
+					foo: 'asc',
+					bar: 'desc'
+				}
+			});
+
+			mockRequire.stop(modelPath);
+		});
+
+		/* eslint-disable-next-line max-len */
+		it('Should pass client defined parameters to the model get when it receives an array to sorted with and set default sort direction if pass undefined', async () => {
+
+			class MyModel {
+				async get() {
+					return [];
+				}
+			}
+
+			mockRequire(modelPath, MyModel);
+
+			sinon.spy(MyModel.prototype, 'get');
+
+			class MyApiListData extends ApiListData {
+				get sortableFields() {
+					return ['foo', 'bar'];
+				}
+			}
+
+			const apiListData = new MyApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {
+				sortBy: ['foo', 'bar'],
+				sortDirection: [undefined, 'DESC']
+			};
+			apiListData.headers = {
+				'x-janis-page': 2,
+				'x-janis-page-size': 20
+			};
+
+			await apiListData.validate();
+
+			await apiListData.process();
+
+			sinon.assert.calledOnceWithExactly(MyModel.prototype.get, {
+				page: 2,
+				limit: 20,
+				order: {
+					foo: 'asc',
+					bar: 'desc'
 				}
 			});
 


### PR DESCRIPTION
### Link al ticket
- https://fizzmod.atlassian.net/browse/JCN-351
- https://fizzmod.atlassian.net/browse/JCN-352

### Descripción del requerimiento
Se requiere mejorar el package [npm: @janiscommerce/api-list](https://www.npmjs.com/package/@janiscommerce/api-list)  para poder implementar múltiples ordenamientos.
Ordenamiento
Se deberá poder ordenar por múltiples fields de la siguiente forma:
- Sin sortDirection:
  - Request: 
    - ?sortBy[0]=field1&sortBy[1]=field2
  - Resultado: 
    - sortBy: ['field1', 'field2'],
    - sortDirection: ['asc', 'asc'] // se toma el default del package
- Con sortDirection igual para cada field:
  - Request: 
    - ?sortBy[0]=field1&sortBy[1]=field2&sortDirection=asc
  - Resultado: 
    - sortBy: ['field1', 'field2'],
    - sortDirection: ['asc', 'asc']
- Con sortDirection definido para un field:
  - Request: 
    - ?sortBy[0]=field1&sortBy[1]=field2&sortDirection[1]=desc
  - Resultado: 
    - sortBy: ['field1', 'field2'],
    - sortDirection: ['asc', 'desc']
### Changelog
- Add multiple sort fields and sort directions