### PR TITLE
Jcn 366 subtarea1 sumar parametros custom a api list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- New optional field `customParameters`. 
+- Optional getter `customParameters` in `apiListData` class for API custom query parameters.
 
 ## [5.2.1] - 2022-03-11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New optional field `customParameters`. 
 
 ## [5.2.1] - 2022-03-11
 ### Added

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ module.exports = class MyApi extends ApiListData {
 			additionalParameter: 'string?' // This parameter can be optional
 		};
 	}
-}
+};
 
 /* 
     This will allow the API to use custom query parameters, example:

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ module.exports = class MyApiListData extends ApiListData {
 
 ### get customParameters()
 
-This allows you to set custom **query parameters** for your API, it must contain the names of the custom parameters that the API will receive
+This allows you to set custom **query parameters** for your API, it must contain the names (keys) and and data type (values) of the custom parameters that the API will receive.
 
 For example:
 
@@ -311,8 +311,10 @@ const { ApiListData } = require('@janiscommerce/api-list');
 module.exports = class MyApi extends ApiListData {
 
     get customParameters() {
-        return ['additionalParameter']
-    }
+        return {
+			additionalParameter: 'string?' // This parameter can be optional
+		};
+	}
 }
 
 /* 

--- a/README.md
+++ b/README.md
@@ -296,3 +296,25 @@ module.exports = class MyApiListData extends ApiListData {
 	}
 };
 ```
+
+### get customParameters()
+
+This is used to set custom parameters for the request. It's optional. Additional parameters will be arrives by `this.data`.
+
+For example:
+We need to define that if a `customParameters` arrives with some value, extra fields are added to the list.
+
+```js
+'use strict';
+
+const {
+	ApiListData
+} = require('@janiscommerce/api-list');
+
+module.exports = class MyApiListData extends ApiListData {
+
+	customParameters() {
+
+		return ['fooData'];
+	}
+};

--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ module.exports = class MyApiListData extends ApiListData {
 ### get customParameters()
 
 This allows you to set custom **query parameters** for your API, it must contain the names (keys) and and data type (values) of the custom parameters that the API will receive.
+The `customParameters` and its values will be in `this.data` to use them in your API.
 
 For example:
 
@@ -314,6 +315,17 @@ module.exports = class MyApi extends ApiListData {
         return {
 			additionalParameter: 'string?' // This parameter can be optional
 		};
+	}
+
+	async formatRows(rows) {
+
+		// To access the parameter, the information arrives through `this.data`
+		if(this.data.additionalParameter === 'someData')
+		
+			// Do something with the additional parameter
+			return rows.map(row => ({ ...row, oneMoreField: true }));
+
+		return rows.map(row => (row));
 	}
 };
 

--- a/README.md
+++ b/README.md
@@ -301,9 +301,9 @@ module.exports = class MyApiListData extends ApiListData {
 
 This allows you to set custom **query parameters** for your API.
 
-Can be customized by passing an object with the following properties:
+Can be customized by passing a string or object with the following properties:
 - `name`: (string) The name of the custom param. This property is required.
-- `valueMapper`: (function) A function to be called on the filter's value. This is optional.
+- `valueMapper`: (function) A function to be called on the parameter's value. This is optional.
 
 The `customParameters` and its values will be in `this.data` to use them in your API.
 
@@ -320,8 +320,8 @@ module.exports = class MyApi extends ApiListData {
         return [
 			'someParam', // default string
 			{
-				name: 'otherParam',
-				valueMapper: booleanMapper
+				name: 'numericParam',
+				valueMapper: Number
 			}
 		];
 	}
@@ -329,7 +329,7 @@ module.exports = class MyApi extends ApiListData {
 	async formatRows(rows) {
 
 		// To access the parameter, the information arrives through `this.data`
-		if(this.data.otherParam === true)
+		if(this.data.numericParam === 1)
 		
 			// Do something with the additional parameter
 			return rows.map(row => ({ ...row, oneMoreField: true }));
@@ -340,6 +340,6 @@ module.exports = class MyApi extends ApiListData {
 
 /* 
     This will allow the API to use custom query parameters, example:
-    https://domain.com/api/my-api-list?otherParam=true
+    https://domain.com/api/my-api-list?numericParam=1
 */
 ```

--- a/README.md
+++ b/README.md
@@ -299,22 +299,24 @@ module.exports = class MyApiListData extends ApiListData {
 
 ### get customParameters()
 
-This is used to set custom parameters for the request. It's optional. Additional parameters will be arrives by `this.data`.
+This allows you to set custom **query parameters** for your API, it must contain the names of the custom parameters that the API will receive
 
 For example:
-We need to define that if a `customParameters` arrives with some value, extra fields are added to the list.
 
 ```js
 'use strict';
 
-const {
-	ApiListData
-} = require('@janiscommerce/api-list');
+const { ApiListData } = require('@janiscommerce/api-list');
 
-module.exports = class MyApiListData extends ApiListData {
+module.exports = class MyApi extends ApiListData {
 
-	customParameters() {
+    get customParameters() {
+        return ['additionalParameter']
+    }
+}
 
-		return ['fooData'];
-	}
-};
+/* 
+    This will allow the API to use custom query parameters, example:
+    https://domain.com/api/my-api-list?additionalParameter='someData'
+*/
+```

--- a/README.md
+++ b/README.md
@@ -299,7 +299,12 @@ module.exports = class MyApiListData extends ApiListData {
 
 ### get customParameters()
 
-This allows you to set custom **query parameters** for your API, it must contain the names (keys) and and data type (values) of the custom parameters that the API will receive.
+This allows you to set custom **query parameters** for your API.
+
+Can be customized by passing an object with the following properties:
+- `name`: (string) The name of the custom param. This property is required.
+- `valueMapper`: (function) A function to be called on the filter's value. This is optional.
+
 The `customParameters` and its values will be in `this.data` to use them in your API.
 
 For example:
@@ -312,15 +317,19 @@ const { ApiListData } = require('@janiscommerce/api-list');
 module.exports = class MyApi extends ApiListData {
 
     get customParameters() {
-        return {
-			additionalParameter: 'string?' // This parameter can be optional
-		};
+        return [
+			'someParam', // default string
+			{
+				name: 'otherParam',
+				valueMapper: booleanMapper
+			}
+		];
 	}
 
 	async formatRows(rows) {
 
 		// To access the parameter, the information arrives through `this.data`
-		if(this.data.additionalParameter === 'someData')
+		if(this.data.otherParam === true)
 		
 			// Do something with the additional parameter
 			return rows.map(row => ({ ...row, oneMoreField: true }));
@@ -331,6 +340,6 @@ module.exports = class MyApi extends ApiListData {
 
 /* 
     This will allow the API to use custom query parameters, example:
-    https://domain.com/api/my-api-list?additionalParameter='someData'
+    https://domain.com/api/my-api-list?otherParam=true
 */
 ```

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -69,10 +69,10 @@ module.exports = class ApiListData extends API {
 	/**
 	 * Get the customParameters.
 	 *
-	 * @returns {Array} - The custom parameters.
+	 * @returns {Object} - The custom parameters.
 	 */
 	get customParameters() {
-		return [];
+		return {};
 	}
 
 	/**
@@ -90,10 +90,12 @@ module.exports = class ApiListData extends API {
 			...this.parents
 		};
 
+		this.customParameter = new CustomParameter(this.data, this.customParameters);
 		this.filter = new Filter(requestFilters, this.availableFilters, this.searchFilters, this.staticFilters);
 		this.paging = new Paging(this.headers, (this.session && this.session.isService));
 		this.sort = new Sort(this.data, this.sortableFields);
-		this.customParameter = new CustomParameter(this.data, this.customParameters);
+
+		this.customParameter.validate();
 
 		const listDataStruct = struct({
 			...this.filter.struct(),

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -99,7 +99,7 @@ module.exports = class ApiListData extends API {
 
 			this.sort.validate();
 
-			this.customParameter.formatCustomParameters(this.data);
+			this.customParameter.format();
 
 			const listDataStruct = struct({
 				...this.filter.struct(),

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -99,20 +99,16 @@ module.exports = class ApiListData extends API {
 
 			this.sort.validate();
 
-			const formattedParameters = this.customParameter.formatCustomParameters(this.data);
-
-			console.log('formattedParameters', formattedParameters);
+			this.customParameter.formatCustomParameters(this.data);
 
 			const listDataStruct = struct({
 				...this.filter.struct(),
 				...this.sort.struct(),
-				...this.customParameter.struct(formattedParameters)
+				...this.customParameter.struct()
 			}, {
 				...this.filter.defaults(),
 				...this.sort.defaults()
 			});
-
-			console.log('listDataStruct-->', listDataStruct);
 
 			this.dataWithDefaults = listDataStruct({
 				...this.data,

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -67,9 +67,9 @@ module.exports = class ApiListData extends API {
 	}
 
 	/**
-	 * Get the customParameters.
+	 * Get the custom query parameters.
 	 *
-	 * @returns {Object} - The custom parameters.
+	 * @returns {Object} - The custom query parameters struct.
 	 */
 	get customParameters() {
 		return {};
@@ -95,25 +95,24 @@ module.exports = class ApiListData extends API {
 		this.paging = new Paging(this.headers, (this.session && this.session.isService));
 		this.sort = new Sort(this.data, this.sortableFields);
 
-		this.customParameter.validate();
-
-		const listDataStruct = struct({
-			...this.filter.struct(),
-			...this.sort.struct(),
-			...this.customParameter.struct()
-		}, {
-			...this.filter.defaults(),
-			...this.sort.defaults()
-		});
-
 		try {
+
+			this.customParameter.validate();
+			this.sort.validate();
+
+			const listDataStruct = struct({
+				...this.filter.struct(),
+				...this.sort.struct(),
+				...this.customParameter.struct()
+			}, {
+				...this.filter.defaults(),
+				...this.sort.defaults()
+			});
 
 			this.dataWithDefaults = listDataStruct({
 				...this.data,
 				...(Object.keys(requestFilters).length ? { filters: requestFilters } : {})
 			});
-
-			this.sort.validate();
 
 		} catch(e) {
 			throw new ApiListError(e, ApiListError.codes.INVALID_REQUEST_DATA);

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -69,10 +69,10 @@ module.exports = class ApiListData extends API {
 	/**
 	 * Get the custom query parameters.
 	 *
-	 * @returns {Object} - The custom query parameters struct.
+	 * @returns {Array} - The custom query parameters struct.
 	 */
 	get customParameters() {
-		return {};
+		return [];
 	}
 
 	/**
@@ -97,17 +97,22 @@ module.exports = class ApiListData extends API {
 
 		try {
 
-			this.customParameter.validate();
 			this.sort.validate();
+
+			const formattedParameters = this.customParameter.formatCustomParameters(this.data);
+
+			console.log('formattedParameters', formattedParameters);
 
 			const listDataStruct = struct({
 				...this.filter.struct(),
 				...this.sort.struct(),
-				...this.customParameter.struct()
+				...this.customParameter.struct(formattedParameters)
 			}, {
 				...this.filter.defaults(),
 				...this.sort.defaults()
 			});
+
+			console.log('listDataStruct-->', listDataStruct);
 
 			this.dataWithDefaults = listDataStruct({
 				...this.data,

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -95,11 +95,11 @@ module.exports = class ApiListData extends API {
 		this.paging = new Paging(this.headers, (this.session && this.session.isService));
 		this.sort = new Sort(this.data, this.sortableFields);
 
+		this.customParameter.format();
+
 		try {
 
 			this.sort.validate();
-
-			this.customParameter.format();
 
 			const listDataStruct = struct({
 				...this.filter.struct(),

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -7,7 +7,7 @@ const path = require('path');
 const EndpointParser = require('./helpers/endpoint-parser');
 
 const ApiListError = require('./api-list-error');
-const { Filter, Paging, Sort } = require('./data-helpers');
+const { Filter, Paging, Sort, CustomParameter } = require('./data-helpers');
 
 /**
  * @class ApiListData
@@ -67,6 +67,15 @@ module.exports = class ApiListData extends API {
 	}
 
 	/**
+	 * Get the customParameters.
+	 *
+	 * @returns {Array} - The custom parameters.
+	 */
+	get customParameters() {
+		return [];
+	}
+
+	/**
 	 * Validate the endpoint and structs of the request before process
 	 *
 	 * @async
@@ -84,10 +93,12 @@ module.exports = class ApiListData extends API {
 		this.filter = new Filter(requestFilters, this.availableFilters, this.searchFilters, this.staticFilters);
 		this.paging = new Paging(this.headers, (this.session && this.session.isService));
 		this.sort = new Sort(this.data, this.sortableFields);
+		this.customParameter = new CustomParameter(this.data, this.customParameters);
 
 		const listDataStruct = struct({
 			...this.filter.struct(),
-			...this.sort.struct()
+			...this.sort.struct(),
+			...this.customParameter.struct()
 		}, {
 			...this.filter.defaults(),
 			...this.sort.defaults()

--- a/lib/api-list-error.js
+++ b/lib/api-list-error.js
@@ -25,6 +25,7 @@ module.exports = class ApiListError extends Error {
 			INVALID_REQUEST_DATA: 1,
 			INVALID_ENTITY: 2,
 			INVALID_FILTERS: 3,
+			INVALID_PARAMETERS: 4,
 			INTERNAL_ERROR: 99
 		};
 	}

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -12,7 +12,7 @@ module.exports = class ListCustomParameters {
 	validate() {
 
 		if(!isObject(this.customParameters))
-			throw new Error('The custom parameter must be an object');
+			throw new Error('The custom parameters must be an object');
 	}
 
 	struct() {

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -18,5 +18,4 @@ module.exports = class ListCustomParameters {
 	struct() {
 		return this.customParameters;
 	}
-
 };

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -9,43 +9,45 @@ const apiCustomParameterStruct = {
 	customParameters: ['string|object']
 };
 
+const apiReservedParams = [
+	'filters',
+	'sortBy',
+	'sortDirection'
+];
+
 module.exports = class ListCustomParameters {
 
 	constructor(requestParameters, customParameters) {
 
 		this.requestParameters = requestParameters;
-		this.customParameters = customParameters.map(customParameter => {
-			return typeof customParameter === 'object' ? customParameter : { name: customParameter };
-		});
+		this.customParameters = customParameters;
 	}
 
-	validate() {
+	format() {
 
 		try {
 
 			struct(apiCustomParameterStruct)({ customParameters: this.customParameters });
 
-			const reservedWords = ['filters', 'sortBy', 'sortDirection'];
+			this.customParameters = this.customParameters.reduce((formattedParameters, parameter) => {
 
-			this.customParameters.forEach(customParameter => {
-				if(reservedWords.includes(customParameter.name))
-					throw new Error(`The custom parameter name "${customParameter.name}" is reserved word`);
-			});
+				parameter = typeof parameter === 'object' ? parameter : { name: parameter };
+
+				if(apiReservedParams.includes(parameter.name))
+					throw new Error(`The custom parameter name "${parameter.name}" is a reserved parameter name.`);
+
+				if(this.requestParameters[parameter.name] === undefined)
+					return formattedParameters;
+
+				this.requestParameters[parameter.name] = mapperFilter(this.requestParameters[parameter.name], parameter.valueMapper);
+
+				formattedParameters.push(parameter);
+				return formattedParameters;
+			}, []);
 
 		} catch(error) {
 			throw new ApiListError(error, ApiListError.codes.INVALID_PARAMETERS);
 		}
-	}
-
-	format() {
-
-		this.validate();
-
-		return this.customParameters.filter(params => {
-			return this.requestParameters[params.name] !== undefined;
-		}).forEach(params => {
-			this.requestParameters[params.name] = mapperFilter(this.requestParameters[params.name], params.valueMapper);
-		});
 	}
 
 	struct() {

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -3,7 +3,7 @@
 const { struct } = require('@janiscommerce/superstruct');
 const ApiListError = require('../api-list-error');
 
-const { mapperFilter } = require('../helpers/mapper-filter');
+const mapperFilter = require('../helpers/mapper-filter');
 
 const apiCustomParameterStruct = {
 	customParameters: ['string|object']
@@ -13,41 +13,47 @@ module.exports = class ListCustomParameters {
 
 	constructor(requestParameters, customParameters) {
 
-		this.validate({ customParameters });
-
 		this.requestParameters = requestParameters;
 		this.customParameters = customParameters.map(customParameter => {
 			return typeof customParameter === 'object' ? customParameter : { name: customParameter };
 		});
 	}
 
-	validate(customParameters) {
+	validate() {
 
 		try {
-			struct(apiCustomParameterStruct)(customParameters);
+
+			struct(apiCustomParameterStruct)({ customParameters: this.customParameters });
+
+			const reservedWords = ['filters', 'sortBy', 'sortDirection'];
+
+			this.customParameters.forEach(customParameter => {
+				if(reservedWords.includes(customParameter.name))
+					throw new Error(`The custom parameter name "${customParameter.name}" is reserved word`);
+			});
+
 		} catch(error) {
-			throw new ApiListError(error);
+			throw new ApiListError(error, ApiListError.codes.INVALID_PARAMETERS);
 		}
 	}
 
-	formatCustomParameters(customParameters) {
+	format() {
+
+		this.validate();
 
 		return this.customParameters.filter(params => {
-			return customParameters[params.name] !== undefined;
+			return this.requestParameters[params.name] !== undefined;
 		}).forEach(params => {
-
-			customParameters[params.name] = mapperFilter(customParameters[params.name], params.valueMapper);
+			this.requestParameters[params.name] = mapperFilter(this.requestParameters[params.name], params.valueMapper);
 		});
 	}
 
 	struct() {
 
-		const customParameters = [...this.customParameters];
-
-		if(!customParameters.length)
+		if(!this.customParameters.length)
 			return {};
 
-		return customParameters.reduce((customParameter, parameter) => {
+		return this.customParameters.reduce((customParameter, parameter) => {
 			customParameter[parameter.name] = struct.optional('string | number | boolean | array | object');
 			return customParameter;
 		}, {});

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -1,21 +1,78 @@
 'use strict';
 
-const isObject = require('../helpers/is-object');
+const { struct } = require('@janiscommerce/superstruct');
+const ApiListError = require('../api-list-error');
+
+const apiCustomParameterStruct = {
+	customParameters: ['string|object']
+};
 
 module.exports = class ListCustomParameters {
 
 	constructor(requestParameters, customParameters) {
+
+		this.validate({ customParameters });
+
 		this.requestParameters = requestParameters;
-		this.customParameters = customParameters;
+		this.customParameters = customParameters.map(customParameter => {
+			return typeof customParameter === 'object' ? customParameter : { name: customParameter };
+		});
 	}
 
-	validate() {
+	validate(customParameters) {
 
-		if(!isObject(this.customParameters))
-			throw new Error('The custom parameters must be an object');
+		try {
+			struct(apiCustomParameterStruct)(customParameters);
+		} catch(error) {
+			throw new ApiListError(error);
+		}
 	}
 
-	struct() {
-		return this.customParameters;
+	formatCustomParameters(customParameters) {
+
+		return this.customParameters.filter(params => {
+			return customParameters[params.name] !== undefined;
+		}).reduce((parameters, params) => {
+
+			const originalValue = customParameters[params.name];
+
+			const filterValue = this.applyFilter(originalValue, params.valueMapper);
+
+			const internalName = params.internalName || params.name;
+
+			const finalName = typeof internalName === 'function' ? internalName(params, filterValue, originalValue) : internalName;
+
+			return {
+				...parameters,
+				[finalName]: filterValue
+			};
+		}, {});
+	}
+
+	applyFilter(originalValue, valueMapper) {
+
+		if(!valueMapper)
+			return originalValue;
+
+		if(valueMapper.isCustom)
+			return valueMapper.map(originalValue);
+
+		return Array.isArray(originalValue) ? originalValue.map(valueMapper) : valueMapper(originalValue);
+	}
+
+	struct(formattedParameters) {
+
+		if(!formattedParameters)
+			return {};
+
+		const customParameterStruct = {};
+
+		for(const [key] of Object.entries(formattedParameters))
+			customParameterStruct[key] = struct.optional('string | number | array | object | boolean');
+
+		return Object.keys(formattedParameters).reduce((parameter, key) => {
+			parameter[key] = customParameterStruct[key];
+			return parameter;
+		}, {});
 	}
 };

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -13,7 +13,6 @@ module.exports = class ListCustomParameters {
 
 		const customParameter = this.customParameters;
 
-
 		if(!customParameter.length)
 			return {};
 

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { struct } = require('@janiscommerce/superstruct');
+const isObject = require('../helpers/is-object');
 
 module.exports = class ListCustomParameters {
 
@@ -9,14 +9,14 @@ module.exports = class ListCustomParameters {
 		this.customParameters = customParameters;
 	}
 
-	struct() {
+	validate() {
 
-		if(!this.customParameters.length)
-			return {};
-
-		return this.customParameters.reduce((customParameters, parameterName) => {
-			customParameters[parameterName] = struct.optional('string');
-			return customParameters;
-		}, {});
+		if(!isObject(this.customParameters))
+			throw new Error('The custom parameter must be an object');
 	}
+
+	struct() {
+		return this.customParameters;
+	}
+
 };

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const { struct } = require('@janiscommerce/superstruct');
+
+module.exports = class ListCustomParameters {
+
+	constructor(requestParameters, customParameters) {
+		this.requestParameters = requestParameters;
+		this.customParameters = customParameters;
+	}
+
+	struct() {
+
+		const customParameter = this.customParameters;
+
+
+		if(!customParameter.length)
+			return {};
+
+		return {
+			[customParameter]: struct.optional('string')
+		};
+	}
+};

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -11,13 +11,12 @@ module.exports = class ListCustomParameters {
 
 	struct() {
 
-		const customParameter = this.customParameters;
-
-		if(!customParameter.length)
+		if(!this.customParameters.length)
 			return {};
 
-		return {
-			[customParameter]: struct.optional('string')
-		};
+		return this.customParameters.reduce((customParameters, parameterName) => {
+			customParameters[parameterName] = struct.optional('string');
+			return customParameters;
+		}, {});
 	}
 };

--- a/lib/data-helpers/custom-parameter.js
+++ b/lib/data-helpers/custom-parameter.js
@@ -3,6 +3,8 @@
 const { struct } = require('@janiscommerce/superstruct');
 const ApiListError = require('../api-list-error');
 
+const { mapperFilter } = require('../helpers/mapper-filter');
+
 const apiCustomParameterStruct = {
 	customParameters: ['string|object']
 };
@@ -32,47 +34,22 @@ module.exports = class ListCustomParameters {
 
 		return this.customParameters.filter(params => {
 			return customParameters[params.name] !== undefined;
-		}).reduce((parameters, params) => {
+		}).forEach(params => {
 
-			const originalValue = customParameters[params.name];
-
-			const filterValue = this.applyFilter(originalValue, params.valueMapper);
-
-			const internalName = params.internalName || params.name;
-
-			const finalName = typeof internalName === 'function' ? internalName(params, filterValue, originalValue) : internalName;
-
-			return {
-				...parameters,
-				[finalName]: filterValue
-			};
-		}, {});
+			customParameters[params.name] = mapperFilter(customParameters[params.name], params.valueMapper);
+		});
 	}
 
-	applyFilter(originalValue, valueMapper) {
+	struct() {
 
-		if(!valueMapper)
-			return originalValue;
+		const customParameters = [...this.customParameters];
 
-		if(valueMapper.isCustom)
-			return valueMapper.map(originalValue);
-
-		return Array.isArray(originalValue) ? originalValue.map(valueMapper) : valueMapper(originalValue);
-	}
-
-	struct(formattedParameters) {
-
-		if(!formattedParameters)
+		if(!customParameters.length)
 			return {};
 
-		const customParameterStruct = {};
-
-		for(const [key] of Object.entries(formattedParameters))
-			customParameterStruct[key] = struct.optional('string | number | array | object | boolean');
-
-		return Object.keys(formattedParameters).reduce((parameter, key) => {
-			parameter[key] = customParameterStruct[key];
-			return parameter;
+		return customParameters.reduce((customParameter, parameter) => {
+			customParameter[parameter.name] = struct.optional('string | number | boolean | array | object');
+			return customParameter;
 		}, {});
 	}
 };

--- a/lib/data-helpers/filter.js
+++ b/lib/data-helpers/filter.js
@@ -8,7 +8,7 @@ const apiFilterStruct = {
 	searchFilters: ['string'],
 	staticFilters: 'object'
 };
-class ListFilter {
+module.exports = class ListFilter {
 
 	constructor(requestFilters, availableFilters, searchFilters, staticFilters) {
 
@@ -132,6 +132,4 @@ class ListFilter {
 			};
 		});
 	}
-}
-
-module.exports = ListFilter;
+};

--- a/lib/data-helpers/filter.js
+++ b/lib/data-helpers/filter.js
@@ -3,6 +3,8 @@
 const { struct } = require('@janiscommerce/superstruct');
 const ApiListError = require('../api-list-error');
 
+const { mapperFilter } = require('../helpers/mapper-filter');
+
 const apiFilterStruct = {
 	availableFilters: ['string|object'],
 	searchFilters: ['string'],
@@ -80,7 +82,7 @@ module.exports = class ListFilter {
 
 			const originalValue = clientFiltersWithDefaults[filter.name];
 
-			const filterValue = this.applyFilter(originalValue, filter.valueMapper);
+			const filterValue = mapperFilter(originalValue, filter.valueMapper);
 
 			const internalName = filter.internalName || filter.name;
 
@@ -91,17 +93,6 @@ module.exports = class ListFilter {
 				[finalName]: filterValue
 			};
 		}, {});
-	}
-
-	applyFilter(originalValue, valueMapper) {
-
-		if(!valueMapper)
-			return originalValue;
-
-		if(valueMapper.isCustom)
-			return valueMapper.map(originalValue);
-
-		return Array.isArray(originalValue) ? originalValue.map(valueMapper) : valueMapper(originalValue);
 	}
 
 	getParamsFromSearchFilters({ search: searchOriginalValues } = {}) {

--- a/lib/data-helpers/filter.js
+++ b/lib/data-helpers/filter.js
@@ -3,7 +3,7 @@
 const { struct } = require('@janiscommerce/superstruct');
 const ApiListError = require('../api-list-error');
 
-const { mapperFilter } = require('../helpers/mapper-filter');
+const mapperFilter = require('../helpers/mapper-filter');
 
 const apiFilterStruct = {
 	availableFilters: ['string|object'],

--- a/lib/data-helpers/index.js
+++ b/lib/data-helpers/index.js
@@ -3,9 +3,11 @@
 const Filter = require('./filter');
 const Paging = require('./paging');
 const Sort = require('./sort');
+const CustomParameter = require('./custom-parameter');
 
 module.exports = {
 	Filter,
 	Paging,
-	Sort
+	Sort,
+	CustomParameter
 };

--- a/lib/data-helpers/sort.js
+++ b/lib/data-helpers/sort.js
@@ -9,7 +9,7 @@ const DEFAULT_SORT_DIRECTION = 'asc';
 
 const sortDirections = ['asc', 'desc', 'ASC', 'DESC'];
 
-class ListSort {
+module.exports = class ListSort {
 
 	constructor(requestParameters, sortableFields) {
 		this.requestParameters = requestParameters;
@@ -94,6 +94,4 @@ class ListSort {
 	isString(value) {
 		return typeof value === 'string';
 	}
-}
-
-module.exports = ListSort;
+};

--- a/lib/helpers/is-object.js
+++ b/lib/helpers/is-object.js
@@ -1,3 +1,0 @@
-'use strict';
-
-module.exports = object => object && !Array.isArray(object) && typeof object === 'object';

--- a/lib/helpers/is-object.js
+++ b/lib/helpers/is-object.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = object => object && !Array.isArray(object) && typeof object === 'object';

--- a/lib/helpers/mapper-filter.js
+++ b/lib/helpers/mapper-filter.js
@@ -1,6 +1,6 @@
 'use strict';
 
-module.exports.mapperFilter = (originalValue, valueMapper) => {
+module.exports = (originalValue, valueMapper) => {
 
 	if(!valueMapper)
 		return originalValue;

--- a/lib/helpers/mapper-filter.js
+++ b/lib/helpers/mapper-filter.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports.mapperFilter = (originalValue, valueMapper) => {
+
+	if(!valueMapper)
+		return originalValue;
+
+	if(valueMapper.isCustom)
+		return valueMapper.map(originalValue);
+
+	return Array.isArray(originalValue) ? originalValue.map(valueMapper) : valueMapper(originalValue);
+};

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -498,6 +498,31 @@ describe('Api List Data', () => {
 			assert.strictEqual(validation, undefined);
 		});
 
+		it('should validate when more than one custom parameter is passed', async () => {
+
+			class MyApiListData extends ApiListData {
+
+				get customParameters() {
+					return ['fooData', 'barData'];
+				}
+			}
+
+			const apiListData = new MyApiListData();
+			apiListData.endpoint = '/some-entity';
+			apiListData.data = {
+				fooData: 'true',
+				barData: 'false'
+			};
+			apiListData.headers = {
+				'x-janis-page': '3',
+				'x-janis-page-size': '20'
+			};
+
+			const validation = await apiListData.validate();
+
+			assert.strictEqual(validation, undefined);
+		});
+
 		context('When pass sortBy as array', () => {
 
 			it('Should validate if sortBy property is passed', async () => {

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -467,8 +467,9 @@ describe('Api List Data', () => {
 				};
 				apiListData.headers = {};
 
-				assert.rejects(apiListData.validate(), error => {
-					return error instanceof ApiListError;
+				await assert.rejects(apiListData.validate(), {
+					name: ApiListError.name,
+					code: ApiListError.codes.INVALID_PARAMETERS
 				});
 			});
 

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -470,6 +470,10 @@ describe('Api List Data', () => {
 				get sortableFields() {
 					return ['foo'];
 				}
+
+				get customParameters() {
+					return ['fooData'];
+				}
 			}
 
 			const apiListData = new MyApiListData();
@@ -481,7 +485,8 @@ describe('Api List Data', () => {
 					search: '1000'
 				},
 				sortBy: 'foo',
-				sortDirection: 'asc'
+				sortDirection: 'asc',
+				fooData: 'true'
 			};
 			apiListData.headers = {
 				'x-janis-page': '3',
@@ -708,6 +713,10 @@ describe('Api List Data', () => {
 				get sortableFields() {
 					return ['foo'];
 				}
+
+				get customParameters() {
+					return ['fooData'];
+				}
 			}
 
 			const apiListData = new MyApiListData();
@@ -718,7 +727,8 @@ describe('Api List Data', () => {
 					id2: '100'
 				},
 				sortBy: 'foo',
-				sortDirection: 'asc'
+				sortDirection: 'asc',
+				fooData: 'true'
 			};
 			apiListData.headers = {
 				'x-janis-page': '3',
@@ -820,6 +830,10 @@ describe('Api List Data', () => {
 				get sortableFields() {
 					return ['foo'];
 				}
+
+				get customParameters() {
+					return ['fooData'];
+				}
 			}
 
 			const apiListData = new MyApiListData();
@@ -830,7 +844,8 @@ describe('Api List Data', () => {
 				filters: {
 					id: '10',
 					id2: '100'
-				}
+				},
+				fooData: 'true'
 			};
 			apiListData.headers = {
 				'x-janis-page': 2,

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -461,12 +461,11 @@ describe('Api List Data', () => {
 
 				const apiListData = new MyApiListData();
 				apiListData.endpoint = '/some-entity';
-				apiListData.data =
-					['fooData'];
+				apiListData.data = ['fooData'];
 				apiListData.headers = {};
 
-				await assert.rejects(() => apiListData.validate(), err => {
-					return err && !!err.message.includes('The custom parameter must be an object');
+				assert.rejects(apiListData.validate(), {
+					message: 'The custom parameters must be an object'
 				});
 			});
 

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -536,7 +536,7 @@ describe('Api List Data', () => {
 				apiListData.headers = {};
 
 				await assert.rejects(() => apiListData.validate(), {
-					message: 'The custom parameter name "filters" is reserved word'
+					message: 'The custom parameter name "filters" is a reserved parameter name.'
 				});
 			});
 

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -515,6 +515,31 @@ describe('Api List Data', () => {
 				});
 			});
 
+			it('Should throw if custom parameter include reserved words', async () => {
+
+				class MyApiListData extends ApiListData {
+					get customParameters() {
+						return [
+							{
+								name: 'filters',
+								valueMapper: Number
+							}
+						];
+					}
+				}
+
+				const apiListData = new MyApiListData();
+				apiListData.endpoint = '/some-entity';
+				apiListData.data = {
+					filters: 1
+				};
+				apiListData.headers = {};
+
+				await assert.rejects(() => apiListData.validate(), {
+					message: 'The custom parameter name "filters" is reserved word'
+				});
+			});
+
 			it('Should validate if valid data is passed', async () => {
 
 				class MyApiListData extends ApiListData {


### PR DESCRIPTION
**Requerimiento**
Se requiere modificar el package para que sea posible sumar parámetros custom a las API LIST creadas con el :package:.

Nuevo getter
Se debe sumar un nuevo **getter** opcional `customParameters` que permita configurar un struct para sumar al actual (el que ya valida filters, sortBy y sortDirection)

Se debe documentar el nuevo **getter** y sumar un ejemplo claro.

Solución:
- Se agregó el nuevo **getter** y sus test.
- Se documentó en `README`