### PR TITLE
JCN-379 No enviar filtros vacios en API List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Sending empty filters when filterMappers returned an empty value, now it doesn't return empty filters to avoid issues.
 
 ## [5.3.0] - 2022-03-28
 ### Added

--- a/lib/data-helpers/filter.js
+++ b/lib/data-helpers/filter.js
@@ -84,6 +84,9 @@ module.exports = class ListFilter {
 
 			const filterValue = mapperFilter(originalValue, filter.valueMapper);
 
+			if(filterValue === undefined)
+				return filters;
+
 			const internalName = filter.internalName || filter.name;
 
 			const finalName = typeof internalName === 'function' ? internalName(filter, filterValue, originalValue) : internalName;


### PR DESCRIPTION
**LINK AL TICKET**
https://fizzmod.atlassian.net/browse/JCN-379

**LINK A LA HISTORIA**
https://fizzmod.atlassian.net/browse/JCN-378

**DESCRIPCIÓN DEL REQUERIMIENTO**
Se necesita modificar el package para solucionar un problema:

- Cuando algun filtro se va a usar (llega un dato y se lo intenta transformar según el mapper), pero el dato es undefined , la base no sabe interpretarlo y rompe.
  -  Un ejemplo de esto son filtros de rangos de fechas, donde puede no llegar alguno de los limites/extremos y hoy se rompe porque intenta agregarlo sin éxito.

**DESCRIPCIÓN DE LA SOLUCIÓN**
- Se realizaron los cambios solicitados para que cuando un mapper devuelva un filtro vacio este no pase a los filtros para la DB 😌
