### PR TITLE
add formatSortables method

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,8 @@ module.exports = {
 	},
 
 	parserOptions: {
-		sourceType: 'script'
+		sourceType: 'script',
+		ecmaVersion: 2020
 	},
 
 	rules: {
@@ -51,9 +52,9 @@ module.exports = {
 		'func-names': 0,
 
 		'space-before-function-paren': ['error', {
-			'anonymous': 'never',
-			'named': 'never',
-			'asyncArrow': 'always'
+			anonymous: 'never',
+			named: 'never',
+			asyncArrow: 'always'
 		}],
 
 		'arrow-parens': ['error', 'as-needed'],

--- a/.github/workflows/build-status.yml
+++ b/.github/workflows/build-status.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/coverage-status.yml
+++ b/.github/workflows/coverage-status.yml
@@ -11,10 +11,10 @@ jobs:
 
     - uses: actions/checkout@v1
 
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
 
     - name: npm install, make test-coverage
       run: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
       - run: npm i
       - run: npm test
 
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 14
           registry-url: https://registry.npmjs.org/
       - run: npm i
       - name: Build types

--- a/README.md
+++ b/README.md
@@ -125,7 +125,27 @@ Will sort the list by `foo` in direction `desc` and `bar` in direction `asc`. Th
 
 Will sort the list by `foo` in direction `asc` because is the *default value* and `bar` in direction `desc`
 
+**Using sortableFields objects with valueMapper**
+
+```js
+'use strict';
+
+const { ApiListData } = require('@janiscommerce/api-list');
+
+module.exports = class MyApiListData extends ApiListData {
+
+	get sortableFields() {
+		return [{
+			name: 'foo',
+			valueMapper: () => [['bar0', 'asc'], ['bar1']] // how to use correctly
+		}];
+	}
+};
+```
+Use sortable field valueMapper for return sorts for apply in database instead of sortable field name
+
 ### get availableFilters()
+
 This is used to indicate which fields can be used to filter the list. Any other filter will return a 400 status code.
 Filters can be customized by passing an object with the following properties:
 - `name`: (string) The name of the filter param. This property is required.

--- a/README.md
+++ b/README.md
@@ -135,19 +135,25 @@ const { ApiListData } = require('@janiscommerce/api-list');
 module.exports = class MyApiListData extends ApiListData {
 
 	get sortableFields() {
-		return [{
-			name: 'foo',
-			valueMapper: direction => (
-				direction ? [['bar0', direction], ['bar1', direction]]: [['bar0', 'asc'], ['bar1']]
-			)
-			/*
-				The function in value mapper must be return an array of array with strings.
-				The first string is a sort name and the second is a sort direction.
-				You can use direction passed by data or default from param for make a logic.
-				If not pass a sort direction in array, by default use a direction passed by data or default.
-				The default sort direction is 'asc'
-			*/
-		}];
+		return [
+			{
+				name: 'foo',
+				valueMapper: () => [['bar0', 'asc'], ['bar1']]
+				/*
+					The function in valueMapper must be return an array of array with strings.
+					The first string is a sort name and the second is a sort direction.
+					If not pass a sort direction in array, by default use a direction passed by data for 'foo' or the default sort direction.
+					The default sort direction is 'asc'.
+				*/
+			},
+			{
+				name: 'bar',
+				valueMapper: direction => (
+					direction ? [['bar0', direction], ['bar1', direction]]: [['bar0', 'asc'], ['bar1']]
+				)
+				// You can use the direction passed from the data for 'bar' or the default sort direction to make a logic that comes in the function parameter
+			}
+		];
 	}
 };
 ```

--- a/README.md
+++ b/README.md
@@ -341,3 +341,41 @@ module.exports = class MyApi extends ApiListData {
     https://domain.com/api/my-api-list?numericParam=1
 */
 ```
+
+### async formatSortables(sortables)
+_Since 5.4.0_
+
+This is used to programatically alter the sortables. It will be executed after parsing static and dynamic sortables.
+If you return a falsy value it will not override them. Otherwise, the return value will be used as sortables.
+
+You can use this method, for example, to build complex sorting.
+
+For example:
+
+```js
+'use strict';
+
+const {
+	ApiListData
+} = require('@janiscommerce/api-list');
+
+module.exports = class MyApiListData extends ApiListData {
+
+	async formatSortables(sortables) {
+
+		const currentSorts = Object.keys(sortables).reduce((accum, key) => {
+
+			// We can use 'customFilter' as an identifier for build a complex sorting
+			if(key === 'customFilter') {
+				const customSorts = { someField: 'asc', otherField: 'desc' };
+
+				return { ...accum, ...customSorts };
+			}
+
+			return { ...accum, [key]: sorts[key] };
+		}, {});
+
+		return currentSorts;
+	}
+};
+```

--- a/README.md
+++ b/README.md
@@ -137,7 +137,16 @@ module.exports = class MyApiListData extends ApiListData {
 	get sortableFields() {
 		return [{
 			name: 'foo',
-			valueMapper: () => [['bar0', 'asc'], ['bar1']] // how to use correctly
+			valueMapper: direction => (
+				direction ? [['bar0', direction], ['bar1', direction]]: [['bar0', 'asc'], ['bar1']]
+			)
+			/*
+				The function in value mapper must be return an array of array with strings.
+				The first string is a sort name and the second is a sort direction.
+				You can use direction passed by data or default from param for make a logic.
+				If not pass a sort direction in array, by default use a direction passed by data or default.
+				The default sort direction is 'asc'
+			*/
 		}];
 	}
 };

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -154,9 +154,13 @@ module.exports = class ApiListData extends API {
 			if(this.fieldsToSelect)
 				getParams.fields = this.fieldsToSelect;
 
+			const formatedSortables = await this.formatSortables(getParams.order);
 			const formattedFilters = await this.formatFilters(getParams.filters);
 
-			if(formattedFilters && typeof formattedFilters === 'object')
+			if(this.isValidObject(formatedSortables))
+				getParams.order = formatedSortables;
+
+			if(this.isValidObject(formattedFilters))
 				getParams.filters = formattedFilters;
 
 			const { result, total } = await this.fetchData(getParams);
@@ -169,6 +173,10 @@ module.exports = class ApiListData extends API {
 		} catch(e) {
 			throw new ApiListError(e, ApiListError.codes.INTERNAL_ERROR);
 		}
+	}
+
+	isValidObject(value) {
+		return value && typeof value === 'object';
 	}
 
 	/**
@@ -254,4 +262,13 @@ module.exports = class ApiListData extends API {
 	formatRows(rows) {
 		return rows;
 	}
+
+	/**
+	 * Is used to programatically alter the sortables. It will be executed after parsing static and dynamic sortables.
+	 * This method is used to format the sortables before sending to the DB.
+	 * @param {Object} sortables - The sortables to format
+	 * @returns {Object} - The formatted sortables
+	 */
+	formatSortables() {}
+
 };

--- a/lib/data-helpers/sort.js
+++ b/lib/data-helpers/sort.js
@@ -64,7 +64,7 @@ module.exports = class ListSort {
 
 		const sortParameters = this.isString(rawSortParameters) ? [rawSortParameters] : rawSortParameters;
 
-		if(!sortParameters || !sortParameters.length)
+		if(!sortParameters?.length)
 			return {};
 
 		return sortParameters.reduce((accum, param, idx) => {
@@ -75,7 +75,7 @@ module.exports = class ListSort {
 				DEFAULT_SORT_DIRECTION;
 
 			if(sortableField.valueMapper && typeof sortableField.valueMapper === 'function') {
-				const sortableFieldMapped = sortableField.valueMapper(sortableField.name);
+				const sortableFieldMapped = sortableField.valueMapper(direction);
 
 				if(!Array.isArray(sortableFieldMapped))
 					return accum;

--- a/lib/data-helpers/sort.js
+++ b/lib/data-helpers/sort.js
@@ -21,8 +21,10 @@ module.exports = class ListSort {
 		if(!this.sortableFields.length)
 			return {};
 
+		const formattedSortableFields = this.sortableFields.map(field => field.name || field);
+
 		return {
-			[SORT_PARAMETER]: struct.optional(struct.union([[struct.enum(this.sortableFields)], struct.enum(this.sortableFields)])),
+			[SORT_PARAMETER]: struct.optional(struct.union([[struct.enum(formattedSortableFields)], struct.enum(formattedSortableFields)])),
 			[SORT_DIRECTION_PARAMETER]: struct.optional(struct.union([[struct.enum([...sortDirections, undefined])], struct.enum(sortDirections)]))
 		};
 	}
@@ -42,40 +44,13 @@ module.exports = class ListSort {
 	}
 
 	getParams(clientParamsWithDefaults) {
-
-		const sortParameters = clientParamsWithDefaults[SORT_PARAMETER];
-		const sortDirection = clientParamsWithDefaults[SORT_DIRECTION_PARAMETER];
+		const { sortParameters, sortDirection } = this.getSortParameters(clientParamsWithDefaults);
 
 		if(!sortParameters || !sortParameters.length)
 			return {};
 
-		const sanitizedSortDirection = this.sanitizeSortDirection(sortDirection);
-
-		if(this.isString(sortParameters)) {
-
-			if(sanitizedSortDirection instanceof Array && sanitizedSortDirection[0]) {
-				return {
-					order: {
-						[sortParameters]: sanitizedSortDirection[0]
-					}
-				};
-			}
-
-			return {
-				order: {
-					[sortParameters]: this.isString(sanitizedSortDirection) ? sanitizedSortDirection : DEFAULT_SORT_DIRECTION
-				}
-			};
-		}
-
 		return sortParameters.reduce((accumOfFields, param, index) => {
-
-			if(this.isString(sortDirection)) {
-				accumOfFields.order[param] = sortDirection;
-				return accumOfFields;
-			}
-
-			accumOfFields.order[param] = sortDirection instanceof Array && sortDirection[index] ? sanitizedSortDirection[index] : DEFAULT_SORT_DIRECTION;
+			accumOfFields.order[param] = this.sanitizeSortDirection(sortDirection[index]);
 
 			return accumOfFields;
 		}, {
@@ -83,12 +58,61 @@ module.exports = class ListSort {
 		});
 	}
 
+
+	getSortParameters(clientParamsWithDefaults) {
+		const rawSortParameters = clientParamsWithDefaults[SORT_PARAMETER];
+		const sortDirection = clientParamsWithDefaults[SORT_DIRECTION_PARAMETER];
+
+		const sortParameters = this.isString(rawSortParameters) ? [rawSortParameters] : rawSortParameters;
+
+		if(!sortParameters || !sortParameters.length)
+			return {};
+
+		return sortParameters.reduce((accum, param, idx) => {
+			const sortableField = this.sortableFields.find(field => field === param || field.name === param);
+
+			let direction = DEFAULT_SORT_DIRECTION;
+
+			if(this.isString(sortDirection))
+				direction = sortDirection;
+
+			if(this.isArray(sortDirection) && sortDirection[idx])
+				direction = sortDirection[idx];
+
+			if(sortableField.valueMapper && typeof sortableField.valueMapper === 'function') {
+				const sortableFieldMapped = sortableField.valueMapper(sortableField.name);
+
+				if(!this.isArray(sortableFieldMapped))
+					return accum;
+
+				sortableFieldMapped.forEach(sortData => {
+					if(!this.isArray(sortData))
+						return;
+
+					const [sortBy, sortDir = direction] = sortData;
+
+					if(sortBy && this.isString(sortBy)) {
+						accum.sortParameters.push(sortBy);
+						accum.sortDirection.push(sortDir);
+					}
+				});
+
+				return accum;
+			}
+
+			accum.sortParameters.push(sortableField.name || sortableField);
+			accum.sortDirection.push(direction);
+
+			return accum;
+		}, { sortParameters: [], sortDirection: [] });
+	}
+
 	sanitizeSortDirection(sortDirection) {
+		return sortDirection.toLowerCase();
+	}
 
-		if(this.isString(sortDirection))
-			return sortDirection.toLowerCase();
-
-		return sortDirection.map(direction => direction && direction.toLowerCase());
+	isArray(value) {
+		return value instanceof Array;
 	}
 
 	isString(value) {

--- a/lib/data-helpers/sort.js
+++ b/lib/data-helpers/sort.js
@@ -46,7 +46,7 @@ module.exports = class ListSort {
 	getParams(clientParamsWithDefaults) {
 		const { sortParameters, sortDirection } = this.getSortParameters(clientParamsWithDefaults);
 
-		if(!sortParameters || !sortParameters.length)
+		if(!sortParameters?.length)
 			return {};
 
 		return sortParameters.reduce((accumOfFields, param, index) => {

--- a/lib/data-helpers/sort.js
+++ b/lib/data-helpers/sort.js
@@ -58,7 +58,6 @@ module.exports = class ListSort {
 		});
 	}
 
-
 	getSortParameters(clientParamsWithDefaults) {
 		const rawSortParameters = clientParamsWithDefaults[SORT_PARAMETER];
 		const sortDirection = clientParamsWithDefaults[SORT_DIRECTION_PARAMETER];
@@ -71,22 +70,18 @@ module.exports = class ListSort {
 		return sortParameters.reduce((accum, param, idx) => {
 			const sortableField = this.sortableFields.find(field => field === param || field.name === param);
 
-			let direction = DEFAULT_SORT_DIRECTION;
-
-			if(this.isString(sortDirection))
-				direction = sortDirection;
-
-			if(this.isArray(sortDirection) && sortDirection[idx])
-				direction = sortDirection[idx];
+			const direction = (this.isString(sortDirection) && sortDirection) ||
+				(Array.isArray(sortDirection) && sortDirection[idx]) ||
+				DEFAULT_SORT_DIRECTION;
 
 			if(sortableField.valueMapper && typeof sortableField.valueMapper === 'function') {
 				const sortableFieldMapped = sortableField.valueMapper(sortableField.name);
 
-				if(!this.isArray(sortableFieldMapped))
+				if(!Array.isArray(sortableFieldMapped))
 					return accum;
 
 				sortableFieldMapped.forEach(sortData => {
-					if(!this.isArray(sortData))
+					if(!Array.isArray(sortData))
 						return;
 
 					const [sortBy, sortDir = direction] = sortData;
@@ -109,10 +104,6 @@ module.exports = class ListSort {
 
 	sanitizeSortDirection(sortDirection) {
 		return sortDirection.toLowerCase();
-	}
-
-	isArray(value) {
-		return value instanceof Array;
 	}
 
 	isString(value) {


### PR DESCRIPTION
**Link Ticket**

[JCN-402](https://fizzmod.atlassian.net/browse/JCN-402)
[JCN-401(History)](https://fizzmod.atlassian.net/browse/JCN-401)

**Descripción**
Se deberá implementar la función de “ordenamientos customs” al igual que se hacen con los filtros
El getter sortableFields deberá poder recibir un array de las siguientes cosas:
- Strings (tal cual como funciona actualmente)
- Objetos
- - En donde cada objeto deberá recibir:
- - - **name**: nombre del ordenamiento
- - - **valueMapper**: función custom a aplicar

Se deberá disponibilizar un método `formatSortables`
Deberá recibir los ordenamientos y devolver los mismos
Dicho método se deberá llamarse solo en caso de que exista en la api (tal cual lo hace `formatFilters`)

**Solución**
Se agrego el nuevo método `formatSortables`, tests y documentación.