### PR TITLE
JCN-417-add-fields-getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Getter `fields` to reduce the api response to just the defined fields.
 
 ## [5.6.1] - 2022-08-25
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ module.exports = class MyApiListData extends ApiListData {
 		return ['id', 'name', 'status'];
 	}
 
+	get fields() {
+		return ['name', 'status'];
+	}
+
 	get sortableFields() {
 		return [
 			'id',
@@ -73,6 +77,11 @@ Returns model name. It is intent to be used to change the model's name and it wi
 This is used to indicate which fields should be selected from the DB.
 This allows you to select fields from other tables, and automatically join them in relational databases.
 This fields **must** be defined in the model.
+
+### get fields()
+This is used to select the fields that will be returned.
+The id field is always returned.
+If a field is not found in the row, it will just ignore it.
 
 ### async formatRows(rows)
 You can use this to format your records before they are returned.

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ This allows you to select fields from other tables, and automatically join them 
 This fields **must** be defined in the model.
 
 ### get fields()
-This is used to select the fields that will be returned.
-The id field is always returned.
+This is used to select the fields that will be returned.  
+The id field is always returned.  
 If a field is not found in the row, it will just ignore it.
 
 ### async formatRows(rows)

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -35,6 +35,15 @@ module.exports = class ApiListData extends API {
 	}
 
 	/**
+	 * Get the fields to send in the response.
+	 *
+	 * @returns {Array<String>|undefined} - The fields to select
+	 */
+	get fields() {
+		return undefined;
+	}
+
+	/**
 	 * Get the fields to sort
 	 *
 	 * @returns {Array} - The fields to sort
@@ -178,7 +187,10 @@ module.exports = class ApiListData extends API {
 
 			const { result, total } = await this.fetchData(getParams);
 
-			const rows = await this.formatRows(result);
+			let rows = await this.formatRows(result);
+
+			if(this.fields)
+				rows = this._selectFields(rows);
 
 			this.setBody(rows);
 
@@ -262,6 +274,33 @@ module.exports = class ApiListData extends API {
 			return new Model();
 
 		return this.session.getSessionInstance(Model);
+	}
+
+	/**
+	 * Select the fields to return in the response
+	 *
+	 * @param {Array} rows The rows to select fields from
+	 * @returns {Array} The rows with just the selected fields
+	 */
+	_selectFields(rows) {
+
+		const { fields } = this;
+
+		if(!Array.isArray(fields) || fields.length === 0)
+			return rows;
+
+		const selectedFields = ['id', ...fields];
+
+		return rows.map(row => {
+			const data = {};
+
+			selectedFields.forEach(field => {
+				if(row[field] !== undefined)
+					data[field] = row[field];
+			});
+
+			return data;
+		});
 	}
 
 	/**

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -295,7 +295,7 @@ module.exports = class ApiListData extends API {
 			const data = {};
 
 			selectedFields.forEach(field => {
-				if(row[field] !== undefined)
+				if(typeof row[field] !== 'undefined')
 					data[field] = row[field];
 			});
 

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -187,12 +187,9 @@ module.exports = class ApiListData extends API {
 
 			const { result, total } = await this.fetchData(getParams);
 
-			let rows = await this.formatRows(result);
+			const rows = await this.formatRows(result);
 
-			if(this.fields)
-				rows = this._selectFields(rows);
-
-			this.setBody(rows);
+			this.setBody(this._selectFields(rows));
 
 			if(this.shouldCalculateTotals())
 				this.setHeader(TOTAL_HEADER, total);

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -2829,13 +2829,9 @@ describe('Api List Data', () => {
 			};
 
 			class MyModel {
-				async get() {
-					return [row];
-				}
+				get() {}
 
-				async getTotals() {
-					return { total: 1 };
-				}
+				getTotals() {}
 			}
 
 			const selectFields = fields => {
@@ -2848,11 +2844,20 @@ describe('Api List Data', () => {
 				return data;
 			};
 
+			beforeEach(() => {
+				sinon.stub(MyModel.prototype, 'get')
+					.resolves([row]);
+				sinon.stub(MyModel.prototype, 'getTotals')
+					.resolves({ total: 1 });
+			});
+
+			afterEach(() => {
+				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, { page: 1, limit: 60 });
+				sinon.assert.calledOnce(MyModel.prototype.getTotals);
+			});
+
 			it('Should not skip any field if fields getter is not defined', async () => {
 				mockRequire(modelPath, MyModel);
-
-				sinon.spy(MyModel.prototype, 'get');
-				sinon.spy(MyModel.prototype, 'getTotals');
 
 				const apiListData = new ApiListData();
 				apiListData.endpoint = '/some-entity';
@@ -2868,17 +2873,11 @@ describe('Api List Data', () => {
 					'x-janis-total': 1
 				});
 
-				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, { page: 1, limit: 60 });
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
 				mockRequire.stop(modelPath);
 			});
 
 			it('Should not skip any field if fields getter does not return an array', async () => {
 				mockRequire(modelPath, MyModel);
-
-				sinon.spy(MyModel.prototype, 'get');
-				sinon.spy(MyModel.prototype, 'getTotals');
 
 				class MyApiListData extends ApiListData {
 					get fields() {
@@ -2900,17 +2899,11 @@ describe('Api List Data', () => {
 					'x-janis-total': 1
 				});
 
-				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, { page: 1, limit: 60 });
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
 				mockRequire.stop(modelPath);
 			});
 
 			it('Should not skip any field if fields getter returns an empty array', async () => {
 				mockRequire(modelPath, MyModel);
-
-				sinon.spy(MyModel.prototype, 'get');
-				sinon.spy(MyModel.prototype, 'getTotals');
 
 				class MyApiListData extends ApiListData {
 					get fields() {
@@ -2932,17 +2925,11 @@ describe('Api List Data', () => {
 					'x-janis-total': 1
 				});
 
-				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, { page: 1, limit: 60 });
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
 				mockRequire.stop(modelPath);
 			});
 
 			it('Should return only the fields that are in the fields getter and the id', async () => {
 				mockRequire(modelPath, MyModel);
-
-				sinon.spy(MyModel.prototype, 'get');
-				sinon.spy(MyModel.prototype, 'getTotals');
 
 				class MyApiListData extends ApiListData {
 					get fields() {
@@ -2964,17 +2951,11 @@ describe('Api List Data', () => {
 					'x-janis-total': 1
 				});
 
-				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, { page: 1, limit: 60 });
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
 				mockRequire.stop(modelPath);
 			});
 
 			it('Should just ignore a field if it is not found in the row', async () => {
 				mockRequire(modelPath, MyModel);
-
-				sinon.spy(MyModel.prototype, 'get');
-				sinon.spy(MyModel.prototype, 'getTotals');
 
 				class MyApiListData extends ApiListData {
 					get fields() {
@@ -2995,9 +2976,6 @@ describe('Api List Data', () => {
 				assert.deepStrictEqual(apiListData.response.headers, {
 					'x-janis-total': 1
 				});
-
-				sinon.assert.calledOnceWithExactly(MyModel.prototype.get, { page: 1, limit: 60 });
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
 
 				mockRequire.stop(modelPath);
 			});

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -2820,6 +2820,7 @@ describe('Api List Data', () => {
 		});
 
 		context('fields Getter', () => {
+
 			const row = {
 				id: '63740e295a960370b0ef0045',
 				a: 'test',
@@ -2827,27 +2828,27 @@ describe('Api List Data', () => {
 				c: 'test'
 			};
 
-			const deletefields = (data, fields) => {
-				const rowCopy = { ...data };
+			class MyModel {
+				async get() {
+					return [row];
+				}
+
+				async getTotals() {
+					return { total: 1 };
+				}
+			}
+
+			const selectFields = fields => {
+				const data = {};
 
 				fields.forEach(field => {
-					delete rowCopy[field];
+					data[field] = row[field];
 				});
 
-				return rowCopy;
+				return data;
 			};
 
 			it('Should not skip any field if fields getter is not defined', async () => {
-				class MyModel {
-					async get() {
-						return [row];
-					}
-
-					async getTotals() {
-						return { total: 1 };
-					}
-				}
-
 				mockRequire(modelPath, MyModel);
 
 				sinon.spy(MyModel.prototype, 'get');
@@ -2874,16 +2875,6 @@ describe('Api List Data', () => {
 			});
 
 			it('Should not skip any field if fields getter does not return an array', async () => {
-				class MyModel {
-					async get() {
-						return [row];
-					}
-
-					async getTotals() {
-						return { total: 1 };
-					}
-				}
-
 				mockRequire(modelPath, MyModel);
 
 				sinon.spy(MyModel.prototype, 'get');
@@ -2916,16 +2907,6 @@ describe('Api List Data', () => {
 			});
 
 			it('Should not skip any field if fields getter returns an empty array', async () => {
-				class MyModel {
-					async get() {
-						return [row];
-					}
-
-					async getTotals() {
-						return { total: 1 };
-					}
-				}
-
 				mockRequire(modelPath, MyModel);
 
 				sinon.spy(MyModel.prototype, 'get');
@@ -2958,16 +2939,6 @@ describe('Api List Data', () => {
 			});
 
 			it('Should return only the fields that are in the fields getter and the id', async () => {
-				class MyModel {
-					async get() {
-						return [row];
-					}
-
-					async getTotals() {
-						return { total: 1 };
-					}
-				}
-
 				mockRequire(modelPath, MyModel);
 
 				sinon.spy(MyModel.prototype, 'get');
@@ -2988,7 +2959,7 @@ describe('Api List Data', () => {
 
 				await apiListData.process();
 
-				assert.deepStrictEqual(apiListData.response.body, [deletefields(row, ['b', 'c'])]);
+				assert.deepStrictEqual(apiListData.response.body, [selectFields(['id', 'a'])]);
 				assert.deepStrictEqual(apiListData.response.headers, {
 					'x-janis-total': 1
 				});
@@ -3000,16 +2971,6 @@ describe('Api List Data', () => {
 			});
 
 			it('Should just ignore a field if it is not found in the row', async () => {
-				class MyModel {
-					async get() {
-						return [row];
-					}
-
-					async getTotals() {
-						return { total: 1 };
-					}
-				}
-
 				mockRequire(modelPath, MyModel);
 
 				sinon.spy(MyModel.prototype, 'get');
@@ -3030,7 +2991,7 @@ describe('Api List Data', () => {
 
 				await apiListData.process();
 
-				assert.deepStrictEqual(apiListData.response.body, [deletefields(row, ['b', 'c'])]);
+				assert.deepStrictEqual(apiListData.response.body, [selectFields(['id', 'a'])]);
 				assert.deepStrictEqual(apiListData.response.headers, {
 					'x-janis-total': 1
 				});


### PR DESCRIPTION
**Links:**
[Historia](https://fizzmod.atlassian.net/browse/JCN-410) - [Subtarea](https://fizzmod.atlassian.net/browse/JCN-417)

**DESCRIPCIÓN DEL REQUERIMIENTO:**
Se requiere modificar el package [GitHub - janis-commerce/api-list: A package to handle JANIS List APIs](https://github.com/janis-commerce/api-list) para sumar un nuevo parámetro opcional fields.

El parámetro fields, si se recibe, debe ser una Array de strings

Al ser recibido, justo antes de devolver el listado de objetos, se debe reducir la respuesta según los fields recibidos

Si se recibe un field que no se encuentra en la respuesta, se debe ignorar sin fallar la ejecución

Siempre se debe devolver el campo `id`

**DESCRIPCIÓN DE LA SOLUCIÓN:**

- Se añadió el getter `fields()` para que la api devuelva solos los campos que se declaren en el getter, ademas del campo `id
`.
- Se añadieron tests para probar dicha funcionalidad.
- Se añadieron los cambios al CHANGELOG.md.
- Se añadió la descripción del nuevo comportamiento al README.md.