### PR TITLE
Jcn 440 modify apilist package to use totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,7 +548,8 @@ An ApiListData accepts request _headers_ to modify default behavior.
 |--|--|--|
 |_x-janis-page_|Configure the page of the list to be consulted|**1**|
 |_x-janis-page-size_|The amount of rows to be returned. (max **100**)|**60**||
-|_x-janis-totals_|The package will calculate total using `getTotals()`. _Since 5.6.0_.|**true**||
+|_x-janis-totals_|The package will calculate total using `getTotals()`. _Since X.X.0_.|**false**||
+|_x-janis-only-totals_|The package will calculate only total (no list items in response) using `getTotals()`. _Since X.X.0_.|**false**||
 
 > ℹ️ The maximum page size can be modified with `maxPageSize()` _getter_
 
@@ -562,7 +563,7 @@ An ApiListData will response the following _headers_.
 |_x-janis-page-size_|The page size used in the `get()` command|
 |_x-janis-total_|The total of documents according the filters applied. Calculated with `getTotals()`|
 
-> ℹ️ The total calculation can be avoided using request _header_ _x-janis-totals_ as **false**
+> ℹ️ The total calculation can be obtained using request _header_ _x-janis-totals_ or _header_ _x-janis-only-totals_ as **true**. Using  _header_ _x-janis-only-totals_ will prevent using `get()` command| and no list items will be returned
 
 ## List APIs with parents
 

--- a/README.md
+++ b/README.md
@@ -548,8 +548,8 @@ An ApiListData accepts request _headers_ to modify default behavior.
 |--|--|--|
 |_x-janis-page_|Configure the page of the list to be consulted|**1**|
 |_x-janis-page-size_|The amount of rows to be returned. (max **100**)|**60**||
-|_x-janis-totals_|The package will calculate total using `getTotals()`. _Since X.X.0_.|**false**||
-|_x-janis-only-totals_|The package will calculate only total (no list items in response) using `getTotals()`. _Since X.X.0_.|**false**||
+|_x-janis-totals_|The package will calculate total using `getTotals()`. _Since 7.0.0_.|**false**||
+|_x-janis-only-totals_|The package will calculate only total (no list items in response) using `getTotals()`. _Since 7.0.0_.|**false**||
 
 > ℹ️ The maximum page size can be modified with `maxPageSize()` _getter_
 

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -194,14 +194,17 @@ module.exports = class ApiListData extends API {
 			if(this.isValidObject(formattedFilters))
 				getParams.filters = formattedFilters;
 
+			this.calculateCalculateOnlyTotals = this.shouldCalculateOnlyTotals();
+			this.calculateTotals = this.shouldCalculateTotals();
+
 			const { result, total } = await this.fetchData(getParams);
 
-			if(!this.shouldCalculateOnlyTotals()) {
+			if(!this.calculateCalculateOnlyTotals) {
 				const rows = await this.formatRows(result);
 				this.setBody(rows);
 			}
 
-			if(this.shouldCalculateOnlyTotals() || this.shouldCalculateTotals())
+			if(this.calculateCalculateOnlyTotals || this.calculateTotals)
 				this.setHeader(TOTAL_HEADER, total);
 
 		} catch(e) {
@@ -222,13 +225,13 @@ module.exports = class ApiListData extends API {
 	 */
 	async fetchData(getParams) {
 
-		if(this.shouldCalculateOnlyTotals()) {
+		if(this.calculateCalculateOnlyTotals) {
 			const { total } = await this.model.getTotals();
 			return { total };
 		}
 		const result = await this.model.get(getParams);
 
-		if(this.shouldCalculateTotals()) {
+		if(this.calculateTotals) {
 			const { total } = result.length ? await this.model.getTotals() : { total: 0 };
 			return { total, result };
 		}

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -194,9 +194,8 @@ module.exports = class ApiListData extends API {
 			if(this.isValidObject(formattedFilters))
 				getParams.filters = formattedFilters;
 
-			this.shouldReturnOnlyTotal = this.shouldCalculateOnlyTotals();
 			this.shouldReturnTotal = this.shouldCalculateTotals() || this.shouldCalculateOnlyTotals();
-			this.shouldReturnBody = !this.shouldReturnOnlyTotal;
+			this.shouldReturnBody = !this.shouldCalculateOnlyTotals();
 
 			const { result, total } = await this.fetchData(getParams);
 
@@ -205,7 +204,7 @@ module.exports = class ApiListData extends API {
 			if(this.shouldReturnBody)
 				this.setBody(rows);
 
-			if(this.shouldReturnTotal || this.shouldReturnOnlyTotal)
+			if(this.shouldReturnTotal)
 				this.setHeader(TOTAL_HEADER, total);
 
 		} catch(e) {
@@ -241,7 +240,7 @@ module.exports = class ApiListData extends API {
 		}
 
 
-		if(this.shouldReturnOnlyTotal || this.shouldReturnTotal) {
+		if(this.shouldReturnTotal) {
 
 			const { total } = await this.model.getTotals(getParams.filters);
 			data.total = total;

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -1,8 +1,8 @@
 'use strict';
 
+const path = require('path');
 const { API } = require('@janiscommerce/api');
 const { struct } = require('@janiscommerce/superstruct');
-const path = require('path');
 
 const EndpointParser = require('./helpers/endpoint-parser');
 
@@ -196,12 +196,12 @@ module.exports = class ApiListData extends API {
 
 			const { result, total } = await this.fetchData(getParams);
 
-			if(result && result.length) {
+			if(!this.shouldCalculateOnlyTotals()) {
 				const rows = await this.formatRows(result);
 				this.setBody(rows);
 			}
 
-			if(total)
+			if(this.shouldCalculateOnlyTotals() || this.shouldCalculateTotals())
 				this.setHeader(TOTAL_HEADER, total);
 
 		} catch(e) {
@@ -223,7 +223,7 @@ module.exports = class ApiListData extends API {
 	async fetchData(getParams) {
 
 		if(this.shouldCalculateOnlyTotals()) {
-			const { total } = await this.model.getTotals() || { total: 0 };
+			const { total } = await this.model.getTotals();
 			return { total };
 		}
 		const result = await this.model.get(getParams);

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -12,7 +12,7 @@ const {
 	Fields, Filter, Paging, Sort, CustomParameter
 } = require('./data-helpers');
 
-const { TOTAL_HEADER, CALCULATE_TOTALS_HEADER } = require('./data-helpers/headers');
+const { TOTAL_HEADER, CALCULATE_TOTALS_HEADER, CALCULATE_ONLY_TOTALS_HEADER } = require('./data-helpers/headers');
 
 const { booleanMapper } = require('./filter-mappers');
 
@@ -196,11 +196,12 @@ module.exports = class ApiListData extends API {
 
 			const { result, total } = await this.fetchData(getParams);
 
-			const rows = await this.formatRows(result);
+			if(result && result.length) {
+				const rows = await this.formatRows(result);
+				this.setBody(rows);
+			}
 
-			this.setBody(rows);
-
-			if(this.shouldCalculateTotals())
+			if(total)
 				this.setHeader(TOTAL_HEADER, total);
 
 		} catch(e) {
@@ -221,6 +222,10 @@ module.exports = class ApiListData extends API {
 	 */
 	async fetchData(getParams) {
 
+		if(this.shouldCalculateOnlyTotals()) {
+			const { total } = await this.model.getTotals() || { total: 0 };
+			return { total };
+		}
 		const result = await this.model.get(getParams);
 
 		if(this.shouldCalculateTotals()) {
@@ -229,6 +234,10 @@ module.exports = class ApiListData extends API {
 		}
 
 		return { result };
+	}
+
+	shouldCalculateOnlyTotals() {
+		return booleanMapper(this.headersWithDefaults[CALCULATE_ONLY_TOTALS_HEADER]);
 	}
 
 	shouldCalculateTotals() {

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -194,17 +194,18 @@ module.exports = class ApiListData extends API {
 			if(this.isValidObject(formattedFilters))
 				getParams.filters = formattedFilters;
 
-			this.calculateCalculateOnlyTotals = this.shouldCalculateOnlyTotals();
-			this.calculateTotals = this.shouldCalculateTotals();
+			this.shouldReturnOnlyTotal = this.shouldCalculateOnlyTotals();
+			this.shouldReturnTotal = this.shouldCalculateTotals() || this.shouldCalculateOnlyTotals();
+			this.shouldReturnBody = !this.shouldReturnOnlyTotal;
 
 			const { result, total } = await this.fetchData(getParams);
 
-			if(!this.calculateCalculateOnlyTotals) {
-				const rows = await this.formatRows(result);
-				this.setBody(rows);
-			}
+			const rows = await this.formatRows(result);
 
-			if(this.calculateCalculateOnlyTotals || this.calculateTotals)
+			if(this.shouldReturnBody)
+				this.setBody(rows);
+
+			if(this.shouldReturnTotal || this.shouldReturnOnlyTotal)
 				this.setHeader(TOTAL_HEADER, total);
 
 		} catch(e) {
@@ -225,18 +226,28 @@ module.exports = class ApiListData extends API {
 	 */
 	async fetchData(getParams) {
 
-		if(this.calculateCalculateOnlyTotals) {
-			const { total } = await this.model.getTotals();
-			return { total };
-		}
-		const result = await this.model.get(getParams);
+		const data = {};
+		if(this.shouldReturnBody) {
 
-		if(this.calculateTotals) {
-			const { total } = result.length ? await this.model.getTotals() : { total: 0 };
-			return { total, result };
+			data.result = await this.model.get(getParams);
+
+			if(this.shouldReturnTotal && !data.result.length) {
+
+				data.total = 0;
+
+				return data;
+
+			}
 		}
 
-		return { result };
+
+		if(this.shouldReturnOnlyTotal || this.shouldReturnTotal) {
+
+			const { total } = await this.model.getTotals(getParams.filters);
+			data.total = total;
+
+		}
+		return data;
 	}
 
 	shouldCalculateOnlyTotals() {

--- a/lib/data-helpers/headers.js
+++ b/lib/data-helpers/headers.js
@@ -4,5 +4,6 @@ module.exports = {
 	PAGE_HEADER: 'x-janis-page',
 	PAGE_SIZE_HEADER: 'x-janis-page-size',
 	TOTAL_HEADER: 'x-janis-total',
-	CALCULATE_TOTALS_HEADER: 'x-janis-totals'
+	CALCULATE_TOTALS_HEADER: 'x-janis-totals',
+	CALCULATE_ONLY_TOTALS_HEADER: 'x-janis-only-totals'
 };

--- a/lib/data-helpers/paging.js
+++ b/lib/data-helpers/paging.js
@@ -2,7 +2,7 @@
 
 const { struct } = require('@janiscommerce/superstruct');
 
-const { PAGE_HEADER, PAGE_SIZE_HEADER, CALCULATE_TOTALS_HEADER } = require('./headers');
+const { PAGE_HEADER, PAGE_SIZE_HEADER, CALCULATE_TOTALS_HEADER, CALCULATE_ONLY_TOTALS_HEADER } = require('./headers');
 
 const DEFAULT_PAGE = 1;
 
@@ -36,7 +36,8 @@ module.exports = class ListPaging {
 
 				return `Page size should be a positive integer lesser or equal to ${this.maxPageSize}`;
 			})),
-			[CALCULATE_TOTALS_HEADER]: 'string|boolean' // for all cases like: '1'|'true'|true|
+			[CALCULATE_TOTALS_HEADER]: 'string|boolean', // for all cases like: '1'|'true'|true|
+			[CALCULATE_ONLY_TOTALS_HEADER]: 'string|boolean' // for all cases like: '1'|'true'|true|
 		};
 	}
 
@@ -44,7 +45,8 @@ module.exports = class ListPaging {
 		return {
 			[PAGE_HEADER]: DEFAULT_PAGE,
 			[PAGE_SIZE_HEADER]: DEFAULT_PAGE_SIZE,
-			[CALCULATE_TOTALS_HEADER]: false
+			[CALCULATE_TOTALS_HEADER]: false,
+			[CALCULATE_ONLY_TOTALS_HEADER]: false
 		};
 	}
 

--- a/lib/data-helpers/paging.js
+++ b/lib/data-helpers/paging.js
@@ -44,7 +44,7 @@ module.exports = class ListPaging {
 		return {
 			[PAGE_HEADER]: DEFAULT_PAGE,
 			[PAGE_SIZE_HEADER]: DEFAULT_PAGE_SIZE,
-			[CALCULATE_TOTALS_HEADER]: true
+			[CALCULATE_TOTALS_HEADER]: false
 		};
 	}
 

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -2088,11 +2088,8 @@ describe('Api List Data', () => {
 
 			it('Should not calculate totals if no data is found', async () => {
 
-				sinon.restore();
-				sinon.stub(MyModel.prototype, 'get')
-					.resolves([]);
-				sinon.stub(MyModel.prototype, 'getTotals')
-					.resolves({ total: 0 });
+				MyModel.prototype.get.resolves([]);
+				MyModel.prototype.getTotals.resolves({ total: 0 });
 
 				const myApiList = getApiInstance(ApiListData, {
 					headers: { 'x-janis-totals': true }
@@ -2104,99 +2101,45 @@ describe('Api List Data', () => {
 				await myApiList.process();
 
 				sinon.assert.notCalled(MyModel.prototype.getTotals);
+
 				assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 0 });
-
 			});
 
-			it('Should calculate totals when x-janis-totals header received as true', async () => {
+			[true, 'true', '1'].forEach(value => {
+				it(`Should calculate totals when x-janis-totals header received as ${value} ${typeof value}`, async () => {
 
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-totals': true }
+					const myApiList = getApiInstance(ApiListData, {
+						headers: { 'x-janis-totals': value }
+					});
+
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					sinon.assert.calledOnce(MyModel.prototype.getTotals);
+
+					assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 1 });
 				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 1 });
 			});
 
-			it('Should calculate totals when x-janis-totals header received as true as string', async () => {
+			[false, 'false', '0'].forEach(value => {
+				it(`Should not calculate totals when x-janis-totals header received ${value} ${typeof value}`, async () => {
 
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-totals': 'true' }
+					const myApiList = getApiInstance(ApiListData, {
+						headers: { 'x-janis-totals': value }
+					});
+
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					sinon.assert.notCalled(MyModel.prototype.getTotals);
+
+					assert.deepStrictEqual(myApiList.response.headers, {});
+
 				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 1 });
 			});
 
-			it('Should calculate totals when x-janis-totals header received as 1 as string', async () => {
-
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-totals': '1' }
-				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 1 });
-			});
-
-			it('Should not calculate totals when x-janis-totals header received as false', async () => {
-
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-totals': false }
-				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.notCalled(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, {});
-			});
-
-			it('Should not calculate totals when x-janis-totals header received as false as string', async () => {
-
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-totals': 'false' }
-				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.notCalled(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, {});
-			});
-
-			it('Should not calculate totals when x-janis-totals header received as 0 as string', async () => {
-
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-totals': '0' }
-				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.notCalled(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, {});
-			});
 		});
 
 		describe('Calculate totals only', () => {
@@ -2211,103 +2154,41 @@ describe('Api List Data', () => {
 					.resolves({ total: 1 });
 			});
 
+			[true, 'true', '1'].forEach(value => {
+				it(`Should calculate totals when x-janis-only-totals header received as ${value} ${typeof value}`, async () => {
 
-			it('Should calculate totals when x-janis-only-totals header received as true', async () => {
+					const myApiList = getApiInstance(ApiListData, {
+						headers: { 'x-janis-only-totals': value }
+					});
 
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-only-totals': true }
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					sinon.assert.calledOnce(MyModel.prototype.getTotals);
+					sinon.assert.notCalled(MyModel.prototype.get);
+
+					assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 1 });
+					assert.deepStrictEqual(myApiList.response.body, undefined);
 				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 1 });
-				assert.deepStrictEqual(myApiList.response.body, undefined);
-				sinon.assert.notCalled(MyModel.prototype.get);
 			});
 
-			it('Should calculate totals when x-janis-totals header received as true as string', async () => {
+			[false, 'false', '0'].forEach(value => {
+				it(`Should not calculate totals when x-janis-only-totals header received as ${value}(${typeof value})`, async () => {
 
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-only-totals': true }
+					const myApiList = getApiInstance(ApiListData, {
+						headers: { 'x-janis-only-totals': value }
+					});
+
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					sinon.assert.notCalled(MyModel.prototype.getTotals);
+					sinon.assert.calledOnce(MyModel.prototype.get);
+
+					assert.deepStrictEqual(myApiList.response.headers, {});
 				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 1 });
-				assert.deepStrictEqual(myApiList.response.body, undefined);
-				sinon.assert.notCalled(MyModel.prototype.get);
-			});
-
-			it('Should calculate totals when x-janis-only-totals header received as 1 as string', async () => {
-
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-only-totals': '1' }
-				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.calledOnce(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 1 });
-				assert.deepStrictEqual(myApiList.response.body, undefined);
-
-				sinon.assert.notCalled(MyModel.prototype.get);
-
-			});
-
-			it('Should not calculate totals when x-janis-only-totals header received as false', async () => {
-
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-only-totals': false }
-				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.notCalled(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, {});
-			});
-
-			it('Should not calculate totals when x-janis-only-totals header received as false as string', async () => {
-
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-only-totals': 'false' }
-				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.notCalled(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, {});
-			});
-
-			it('Should not calculate totals when x-janis-only-totals header received as 0 as string', async () => {
-
-				const myApiList = getApiInstance(ApiListData, {
-					headers: { 'x-janis-only-totals': '0' }
-				});
-
-				await myApiList.validate();
-
-				await myApiList.process();
-
-				sinon.assert.notCalled(MyModel.prototype.getTotals);
-
-				assert.deepStrictEqual(myApiList.response.headers, {});
 			});
 
 		});

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -1427,7 +1427,7 @@ describe('Api List Data', () => {
 
 			assertGet();
 
-			sinon.assert.calledOnceWithExactly(MyModel.prototype.getTotals);
+			sinon.assert.calledOnceWithExactly(MyModel.prototype.getTotals, undefined);
 		});
 
 		it('Should return a rows array (formatted) and total rows if passed params do find results', async () => {
@@ -1462,7 +1462,7 @@ describe('Api List Data', () => {
 
 			assertGet();
 
-			sinon.assert.calledOnceWithExactly(MyModel.prototype.getTotals);
+			sinon.assert.calledOnceWithExactly(MyModel.prototype.getTotals, undefined);
 		});
 
 		describe('searchFilters', () => {


### PR DESCRIPTION
### Link de la historia de usuario

https://janiscommerce.atlassian.net/browse/JCN-439

### Link de la/s sub-tareas

https://janiscommerce.atlassian.net/browse/JCN-440

### Descripción del requerimiento

Se necesita modificar el package [API List](https://github.com/janis-commerce/api-list) para poder tener nuevos comportamientos de acuerdo a que headers que lleguen.

Qué headers ?
-------------

Se debe agregar la posibilidad que puedan o no llegar estos nuevos headers:

-   x-janis-totals

-   x-janis-only-totals

Para qué sirven ?
-----------------

Sirve para poder indicarle a la API List qué es lo que hay que devolver.

### Usando "x-janis-totals"

En caso que

-   x-janis-totals: true

**Funciona como hasta ahora:**

-   Envia los items getteadas

-   settea el header x-janis-totals con el total de items en la base (es decir hace el getTotals)

### Usando "x-janis-only-totals"

En caso que

-   x-janis-only-totals: true

El comportamiento cambia:

-   NO envia los items, es decir no debe gettear a la base

-   Settea el header x-janis-totals con el total de items en la base (es decir hace el getTotals)

### Sin Headers

En caso que **no lleguen estos headers**, o

-   y/o x-janis-totals : false

-   y/o x-janis-only-totals : false

Probablemente el caso principal

La API List tiene que devolver los items getteados y **NO settear** x-janis-totals con el total de items en la base, es decir no se debe hacer getTotals.

Donde lo vamos a usar ?
-----------------------

Mirar la Epica, en resumen se trata de obtener el total para paginar 1 sola vez, y no estar requiriendolo todo el rato haciendo trabajar a la base mucho de más.

Otras consideraciones
---------------------

-   El resto de las funcionalidades del package deben continuar funcionando

-   El Readme tiene que actualizarse con los cambios y ser claros de la nuevas modificaciones

### Descripción de la solución

El header `x-janis-totals` ya existe. Se cambió su valor default de true a false en:

`lib/data-helpers/paging.js`

Se agregó el nuevo header `x-janis-only-totals`

`lib/data-helpers/headers.js`

Se ajustó la lógica de process() en 

`lib/api-list-data.js`

para que se corresponda con lo pedido en el ticket

Se agregaron los tests para los nuevos casos

Se modificó el README.md

### Como probarlo
Dejo la request en POSTMAN, ingresar el janis secret que se obtiene desde el navegador en beta: https://www.postman.com/matiasparodi/workspace/janis-public/request/17855456-a4f32168-ac39-4bdf-9d05-9bddea84f11a?ctx=documentation

Probar ingresando los headers. Solo anda para las entidades mp-pet y mp-animal.

### Datos extra a tener en cuenta


En el README se indicó que el cambio se encuentra a partir de la versión 7.0.0 ya que se considera un cambio major no retrocompatible. Esto debe ser chequeado por la persona encargada a mergear

### Screenshots

With no headers in request, body is present

![Screenshot from 2023-08-10 18-07-57](https://github.com/janis-commerce/api-list/assets/81984098/cf5d9741-ee36-4ac0-8382-9f41df887ab0)
![Screenshot from 2023-08-10 18-09-22](https://github.com/janis-commerce/api-list/assets/81984098/4602b881-dc8a-48ac-b727-67a9b91debbc)

With header x-janis-totals, x-janis-total header in response and body is present

![Screenshot from 2023-08-10 18-10-02](https://github.com/janis-commerce/api-list/assets/81984098/9feedbbc-4aae-4870-8caf-d38d6e8e8e52)
![Screenshot from 2023-08-10 18-10-10](https://github.com/janis-commerce/api-list/assets/81984098/0e94174b-f377-4b51-b210-ef280e58b0c9)

With header x-janis-only-totals, x-janis-total header in response and no body

![Screenshot from 2023-08-10 18-10-34](https://github.com/janis-commerce/api-list/assets/81984098/c8f7410f-671f-4f0e-ab94-c21089f3d836)

![Screenshot from 2023-08-10 18-10-49](https://github.com/janis-commerce/api-list/assets/81984098/1793aa90-2c62-4801-9267-14b984516428)




### Changelog

```
### Added 
- New header x-janis-only-totals to make request not return list items, only header x-janis-total

### Changed
- x-janis-total header default from true to false
```