### PR TITLE
JCN-455-Fixed formatRows call with new Headers

### DIFF
--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -199,10 +199,10 @@ module.exports = class ApiListData extends API {
 
 			const { result, total } = await this.fetchData(getParams);
 
-			const rows = await this.formatRows(result);
-
-			if(this.shouldReturnBody)
+			if(this.shouldReturnBody) {
+				const rows = await this.formatRows(result);
 				this.setBody(rows);
+			}
 
 			if(this.shouldReturnTotal)
 				this.setHeader(TOTAL_HEADER, total);
@@ -226,6 +226,7 @@ module.exports = class ApiListData extends API {
 	async fetchData(getParams) {
 
 		const data = {};
+
 		if(this.shouldReturnBody) {
 
 			data.result = await this.model.get(getParams);
@@ -235,17 +236,16 @@ module.exports = class ApiListData extends API {
 				data.total = 0;
 
 				return data;
-
 			}
-		}
+		} else
+			data.result = [];
 
 
 		if(this.shouldReturnTotal) {
-
 			const { total } = await this.model.getTotals(getParams.filters);
 			data.total = total;
-
 		}
+
 		return data;
 	}
 

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -2157,6 +2157,8 @@ describe('Api List Data', () => {
 			[true, 'true', '1'].forEach(value => {
 				it(`Should calculate totals when x-janis-only-totals header received as ${value} ${typeof value}`, async () => {
 
+					sinon.spy(ApiListData.prototype, 'formatRows');
+
 					const myApiList = getApiInstance(ApiListData, {
 						headers: { 'x-janis-only-totals': value }
 					});
@@ -2167,6 +2169,7 @@ describe('Api List Data', () => {
 
 					sinon.assert.calledOnce(MyModel.prototype.getTotals);
 					sinon.assert.notCalled(MyModel.prototype.get);
+					sinon.assert.notCalled(ApiListData.prototype.formatRows);
 
 					assert.deepStrictEqual(myApiList.response.headers, { 'x-janis-total': 1 });
 					assert.deepStrictEqual(myApiList.response.body, undefined);


### PR DESCRIPTION
LINK AL TICKET
[Historia](https://janiscommerce.atlassian.net/browse/JCN-454) | [Subtarea](https://janiscommerce.atlassian.net/browse/JCN-455)

DESCRIPCIÓN DEL REQUERIMIENTO
Se agregaron los nuevos Headers para retornar (o no) los totales y el body, y mejorar la performance de las API de tipo Listado.

Pero cuando una de estas API quiere formatear el resultado de manera custom se rompe, ya que ahora no llega, antes siempre estaba.

Se necesita corregir el package [GitHub - janis-commerce/api-list: A package to handle JANIS List APIs](https://github.com/janis-commerce/api-list)  para evitar que use el `formatRows` cuando ya no tiene que devolver el resultado (por los nuevos headers).

DESCRIPCIÓN DE LA SOLUCIÓN
Se desarrollaron los requerimientos solicitados