### PR TITLE
Jcn 477 skip formatter when fields are reduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ const { ApiListData } = require('@janiscommerce/api-list');
 
 module.exports = class MyApiListData extends ApiListData {
 
+	get alwaysCallFormatter() {
+		return true;
+	}
+
 	get fieldsToSelect() {
 		return ['name', 'status'];
 	}
@@ -76,6 +80,9 @@ All of them are optional.
 
 ### get modelName()
 Returns model name. It is intent to be used to change the model's name and it will not get the model name from endpoint
+
+### get alwaysCallFormatter()
+This is used to force calling the `formatRows()` method even if `fields` or `excludeFields` are sent to the API.
 
 ### get fieldsToSelect()
 This is used to determinate which fields should be selected from the DB.
@@ -209,7 +216,7 @@ _Since 3.1.0_
 
 This lib also exports some value mappers (to use as `valueMapper`) so you don't need to implement them yourself.
 
-> :warning: `startOfTheDayMapper` and `endOfTheDayMapper` are now deprecated. See [migration guide](docs/deprecations/001-start-and-end-of-day-filter-mapper.md).
+> :warning: Warning `startOfTheDayMapper` and `endOfTheDayMapper` are now deprecated. See [migration guide](docs/deprecations/001-start-and-end-of-day-filter-mapper.md).
 
 <details>
 	<summary>They are explained here with examples:</summary>
@@ -487,6 +494,8 @@ module.exports = class MyApiListData extends ApiListData {
 _Since_ `5.8.0`
 
 An Api defined with **ApiListData** can be reduced using new parameters `fields` and `excludeFields`.
+
+> :warning: **Warning** When a response is reduced, it will not call `formatRows()`, unless the API's `alwaysCallFormatter` getter returns `true`
 
 This parameters will be passed to the **model** for reducing the response on the database-side.
 

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -109,6 +109,15 @@ module.exports = class ApiListData extends API {
 	}
 
 	/**
+	 * Set to true if you want the formatter to be called even when response fields are being reduced
+	 *
+	 * @returns {boolean} - Whether or not call the formatter no matter what
+	 */
+	get alwaysCallFormatter() {
+		return false;
+	}
+
+	/**
 	 * Validate the endpoint and structs of the request before process
 	 *
 	 * @async
@@ -200,7 +209,10 @@ module.exports = class ApiListData extends API {
 			const { result, total } = await this.fetchData(getParams);
 
 			if(this.shouldReturnBody) {
-				const rows = await this.formatRows(result);
+
+				const shouldCallFormatter = this.shouldCallFormatter(this.dataWithDefaults);
+
+				const rows = shouldCallFormatter ? await this.formatRows(result) : result;
 				this.setBody(rows);
 			}
 
@@ -212,6 +224,10 @@ module.exports = class ApiListData extends API {
 		}
 	}
 
+	shouldCallFormatter(dataWithDefaults) {
+		return this.alwaysCallFormatter || !this.fields.isResponseReduced(dataWithDefaults);
+	}
+
 	isValidObject(value) {
 		return value && typeof value === 'object';
 	}
@@ -221,7 +237,7 @@ module.exports = class ApiListData extends API {
 	 *
 	 * @async
 	 * @throws {Object} - Params to fetch data
-	 * @returns {Object{result, total}} - The result and total data obtained
+	 * @returns {Promise<{result: Array?, total: number?}>} - The result and total data obtained
 	 */
 	async fetchData(getParams) {
 
@@ -321,7 +337,7 @@ module.exports = class ApiListData extends API {
 	 *
 	 * @async
 	 * @param {Array} rows - The rows to format
-	 * @returns {Array} - The formatted rows
+	 * @returns {Array|Promise<Array>} - The formatted rows
 	 */
 	formatRows(rows) {
 		return rows;

--- a/lib/api-list-data.js
+++ b/lib/api-list-data.js
@@ -209,10 +209,7 @@ module.exports = class ApiListData extends API {
 			const { result, total } = await this.fetchData(getParams);
 
 			if(this.shouldReturnBody) {
-
-				const shouldCallFormatter = this.shouldCallFormatter(this.dataWithDefaults);
-
-				const rows = shouldCallFormatter ? await this.formatRows(result) : result;
+				const rows = this.shouldCallFormatter(this.dataWithDefaults) ? await this.formatRows(result) : result;
 				this.setBody(rows);
 			}
 

--- a/lib/data-helpers/fields.js
+++ b/lib/data-helpers/fields.js
@@ -45,6 +45,10 @@ module.exports = class ListFields {
 		};
 	}
 
+	isResponseReduced(getParams) {
+		return getParams.fields?.length || getParams.excludeFields?.length;
+	}
+
 	canSelectField(field) {
 
 		if(this.fieldsToSelect === false)

--- a/tests/api-list-data.js
+++ b/tests/api-list-data.js
@@ -2348,6 +2348,138 @@ describe('Api List Data', () => {
 
 					assertGet({ fields: ['foo'] });
 				});
+
+				it('Should not format the rows when fields are received', async () => {
+
+					MyModel.prototype.get.resolves([{
+						foo: 'bar'
+					}]);
+
+					class MyApiList extends ApiListData {
+						formatRows(rows) {
+							return rows.map(row => ({
+								...row,
+								newField: true
+							}));
+						}
+					}
+
+					const myApiList = getApiInstance(MyApiList, {
+						data: { fields: ['foo'] }
+					});
+
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					assert.deepStrictEqual(myApiList.response.body, [{
+						foo: 'bar'
+					}]);
+
+					assertGet({ fields: ['foo'] });
+				});
+
+				it('Should format the rows when alwaysCallFormatter is true, even if fields are received', async () => {
+
+					MyModel.prototype.get.resolves([{
+						foo: 'bar'
+					}]);
+
+					class MyApiList extends ApiListData {
+
+						get alwaysCallFormatter() {
+							return true;
+						}
+
+						formatRows(rows) {
+							return rows.map(row => ({
+								...row,
+								newField: true
+							}));
+						}
+					}
+
+					const myApiList = getApiInstance(MyApiList, {
+						data: { fields: ['foo'] }
+					});
+
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					assert.deepStrictEqual(myApiList.response.body, [{
+						foo: 'bar',
+						newField: true
+					}]);
+
+					assertGet({ fields: ['foo'] });
+				});
+
+				it('Should not format the rows when excludeFields are received', async () => {
+
+					MyModel.prototype.get.resolves([{
+						foo: 'bar'
+					}]);
+
+					class MyApiList extends ApiListData {
+						formatRows(rows) {
+							return rows.map(row => ({
+								...row,
+								newField: true
+							}));
+						}
+					}
+
+					const myApiList = getApiInstance(MyApiList, {
+						data: { excludeFields: ['baz'] }
+					});
+
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					assert.deepStrictEqual(myApiList.response.body, [{
+						foo: 'bar'
+					}]);
+
+					assertGet({ excludeFields: ['baz'] });
+				});
+
+				it('Should format the rows when alwaysCallFormatter is true, even if excludeFields are received', async () => {
+
+					MyModel.prototype.get.resolves([{
+						foo: 'bar'
+					}]);
+
+					class MyApiList extends ApiListData {
+
+						get alwaysCallFormatter() {
+							return true;
+						}
+
+						formatRows(rows) {
+							return rows.map(row => ({
+								...row,
+								newField: true
+							}));
+						}
+					}
+
+					const myApiList = getApiInstance(MyApiList, {
+						data: { excludeFields: ['baz'] }
+					});
+
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					assert.deepStrictEqual(myApiList.response.body, [{
+						foo: 'bar',
+						newField: true
+					}]);
+
+					assertGet({ excludeFields: ['baz'] });
+				});
 			});
 
 			context('When Api has fieldsToSelect defined', () => {
@@ -2407,6 +2539,42 @@ describe('Api List Data', () => {
 					await myApiList.process();
 
 					assertGet({ fields: ['bar'] });
+				});
+
+				it('Should format the rows when no fields or excludeFields are received as params', async () => {
+
+					MyModel.prototype.get.resolves([{
+						foo: 'bar'
+					}]);
+
+					class MyApiList extends ApiListData {
+
+						get fieldsToSelect() {
+							return ['foo'];
+						}
+
+						formatRows(rows) {
+							return rows.map(row => ({
+								...row,
+								newField: true
+							}));
+						}
+					}
+
+					const myApiList = getApiInstance(MyApiList, {
+						data: {}
+					});
+
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					assert.deepStrictEqual(myApiList.response.body, [{
+						foo: 'bar',
+						newField: true
+					}]);
+
+					assertGet({ fields: ['foo'] });
 				});
 			});
 
@@ -2520,6 +2688,42 @@ describe('Api List Data', () => {
 					await myApiList.process();
 
 					assertGet({ excludeFields: ['foo'] });
+				});
+
+				it('Should format the rows when no fields or excludeFields are received as params', async () => {
+
+					MyModel.prototype.get.resolves([{
+						foo: 'bar'
+					}]);
+
+					class MyApiList extends ApiListData {
+
+						get fieldsToExclude() {
+							return ['baz'];
+						}
+
+						formatRows(rows) {
+							return rows.map(row => ({
+								...row,
+								newField: true
+							}));
+						}
+					}
+
+					const myApiList = getApiInstance(MyApiList, {
+						data: {}
+					});
+
+					await myApiList.validate();
+
+					await myApiList.process();
+
+					assert.deepStrictEqual(myApiList.response.body, [{
+						foo: 'bar',
+						newField: true
+					}]);
+
+					assertGet({ excludeFields: ['baz'] });
 				});
 			});
 		});


### PR DESCRIPTION
### Link al ticket
[JCN-477](https://janiscommerce.atlassian.net/browse/JCN-477)

### Descripción del requerimiento
Evitar llamar al formatter cuando la respuesta fue reducida por la request

### Descripción de la solución
Se agregaron dos controles:
1. Evitar llamar al formatter cuando se recibe `fields` o `excludeFields`
2. Se llama siempre al formatter (sobreescribiendo el punto 1) si la API settea el getter `alwaysCallFormatter` como `true`

### Cómo se puede probar?
1. Instalar la nueva version en un servicio existente
2. Llamar a una API que tenga formatter y ver que devuelva la data completa y formatteada
3. Volver a llamar con `fields` y validar que solo devuelva esos campos, sin formattear nada
4. Repetir el punto anterior con `excludeFields`
5. Modificar la API setteando el getter `alwaysCallFormatter` como `true` y volver a llamar con `fields` o `excludeFields`, y validar que además de filtrar los campos, pasa por el formatter.

### Datos extra a tener en cuenta
⚠️ Estos cambios implican una version MAJOR.

### Changelog

```
### Added
- API now has a `alwaysCallFormatter` to enforce calling the `formatRows()` method, even when response is reduced with `fields` or `excludeFields`.

### Changed
- **BREAKING CHANGE** When the response is reduced with `fields` or `excludeFields`, the `formatRows()` method is not called any more.
```

[JCN-477]: https://janiscommerce.atlassian.net/browse/JCN-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ